### PR TITLE
Add `Version.xcodeStringValue` getter to get the value to use in Xcode projects.

### DIFF
--- a/Sources/XcodeGraph/Models/Version.swift
+++ b/Sources/XcodeGraph/Models/Version.swift
@@ -34,6 +34,11 @@ public struct Version: Hashable, Codable, Sendable {
         self.prereleaseIdentifiers = prereleaseIdentifiers
         self.buildMetadataIdentifiers = buildMetadataIdentifiers
     }
+
+    /// Returns the value that Xcode projects use internally.
+    public var xcodeStringValue: String {
+        "\(major)\(minor)\(patch)"
+    }
 }
 
 extension Version: Comparable {

--- a/Tests/XcodeGraphTests/Models/VersionTests.swift
+++ b/Tests/XcodeGraphTests/Models/VersionTests.swift
@@ -1,0 +1,16 @@
+import Foundation
+import XcodeGraph
+import XCTest
+
+final class VersionTests: XCTestCase {
+    func test_xcodeStringValue() {
+        // Given
+        let version = Version(stringLiteral: "1.2.3")
+
+        // When
+        let got = version.xcodeStringValue
+
+        // Then
+        XCTAssertEqual(got, "123")
+    }
+}


### PR DESCRIPTION
Tuist users that value when generating Xcode projects so I'm adding a public property to obtain the value