### PR TITLE
Support platform for XCFrameworkInfoPlist

### DIFF
--- a/Sources/XcodeGraph/Graph/GraphDependency.swift
+++ b/Sources/XcodeGraph/Graph/GraphDependency.swift
@@ -5,7 +5,6 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
     public struct XCFramework: Hashable, CustomStringConvertible, Comparable, Codable {
         public let path: AbsolutePath
         public let infoPlist: XCFrameworkInfoPlist
-        public let primaryBinaryPath: AbsolutePath
         public let linking: BinaryLinking
         public let mergeable: Bool
         public let status: FrameworkStatus
@@ -13,7 +12,6 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         public init(
             path: AbsolutePath,
             infoPlist: XCFrameworkInfoPlist,
-            primaryBinaryPath: AbsolutePath,
             linking: BinaryLinking,
             mergeable: Bool,
             status: FrameworkStatus,
@@ -21,7 +19,6 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         ) {
             self.path = path
             self.infoPlist = infoPlist
-            self.primaryBinaryPath = primaryBinaryPath
             self.linking = linking
             self.mergeable = mergeable
             self.status = status
@@ -316,8 +313,6 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         public static func testXCFramework(
             path: AbsolutePath = AbsolutePath.root.appending(try! RelativePath(validating: "Test.xcframework")),
             infoPlist: XCFrameworkInfoPlist = .test(),
-            primaryBinaryPath: AbsolutePath = AbsolutePath.root
-                .appending(try! RelativePath(validating: "Test.xcframework/Test")),
             linking: BinaryLinking = .dynamic,
             status: FrameworkStatus = .required,
             macroPath: AbsolutePath? = nil
@@ -326,7 +321,6 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
                 GraphDependency.XCFramework(
                     path: path,
                     infoPlist: infoPlist,
-                    primaryBinaryPath: primaryBinaryPath,
                     linking: linking,
                     mergeable: false,
                     status: status,

--- a/Sources/XcodeGraph/Models/Metadata/XCFrameworkMetadata.swift
+++ b/Sources/XcodeGraph/Models/Metadata/XCFrameworkMetadata.swift
@@ -5,7 +5,6 @@ import Path
 public struct XCFrameworkMetadata: Equatable {
     public var path: AbsolutePath
     public var infoPlist: XCFrameworkInfoPlist
-    public var primaryBinaryPath: AbsolutePath
     public var linking: BinaryLinking
     public var mergeable: Bool
     public var status: FrameworkStatus
@@ -14,7 +13,6 @@ public struct XCFrameworkMetadata: Equatable {
     public init(
         path: AbsolutePath,
         infoPlist: XCFrameworkInfoPlist,
-        primaryBinaryPath: AbsolutePath,
         linking: BinaryLinking,
         mergeable: Bool,
         status: FrameworkStatus,
@@ -22,7 +20,6 @@ public struct XCFrameworkMetadata: Equatable {
     ) {
         self.path = path
         self.infoPlist = infoPlist
-        self.primaryBinaryPath = primaryBinaryPath
         self.linking = linking
         self.mergeable = mergeable
         self.status = status
@@ -36,9 +33,6 @@ public struct XCFrameworkMetadata: Equatable {
             // swiftlint:disable:next force_try
             path: AbsolutePath = try! AbsolutePath(validating: "/XCFrameworks/XCFramework.xcframework"),
             infoPlist: XCFrameworkInfoPlist = .test(),
-            primaryBinaryPath: AbsolutePath =
-                // swiftlint:disable:next force_try
-                try! AbsolutePath(validating: "/XCFrameworks/XCFramework.xcframework/ios-arm64/XCFramework"),
             linking: BinaryLinking = .dynamic,
             mergeable: Bool = false,
             status: FrameworkStatus = .required,
@@ -47,7 +41,6 @@ public struct XCFrameworkMetadata: Equatable {
             XCFrameworkMetadata(
                 path: path,
                 infoPlist: infoPlist,
-                primaryBinaryPath: primaryBinaryPath,
                 linking: linking,
                 mergeable: mergeable,
                 status: status,

--- a/Sources/XcodeGraph/Models/XCFrameworkInfoPlist.swift
+++ b/Sources/XcodeGraph/Models/XCFrameworkInfoPlist.swift
@@ -12,13 +12,9 @@ public struct XCFrameworkInfoPlist: Codable, Hashable, Equatable {
         private enum CodingKeys: String, CodingKey {
             case identifier = "LibraryIdentifier"
             case path = "LibraryPath"
+            case platform = "SupportedPlatform"
             case architectures = "SupportedArchitectures"
             case mergeable = "MergeableMetadata"
-        }
-
-        /// It represents the library's platform.
-        public enum Platform: String, Hashable, Codable {
-            case ios
         }
 
         /// Binary name used to import the library
@@ -35,6 +31,8 @@ public struct XCFrameworkInfoPlist: Codable, Hashable, Equatable {
         /// Declares if the library is mergeable or not
         public let mergeable: Bool
 
+        public let platform: Platform
+
         /// Architectures the binary is built for.
         public let architectures: [BinaryArchitecture]
 
@@ -50,11 +48,13 @@ public struct XCFrameworkInfoPlist: Codable, Hashable, Equatable {
             identifier: String,
             path: RelativePath,
             mergeable: Bool,
+            platform: Platform,
             architectures: [BinaryArchitecture]
         ) {
             self.identifier = identifier
             self.path = path
             self.mergeable = mergeable
+            self.platform = platform
             self.architectures = architectures
         }
 
@@ -62,6 +62,7 @@ public struct XCFrameworkInfoPlist: Codable, Hashable, Equatable {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             identifier = try container.decode(String.self, forKey: .identifier)
             path = try container.decode(RelativePath.self, forKey: .path)
+            platform = try container.decode(Platform.self, forKey: .platform)
             architectures = try container.decode([BinaryArchitecture].self, forKey: .architectures)
             mergeable = try container.decodeIfPresent(Bool.self, forKey: .mergeable) ?? false
         }
@@ -84,12 +85,14 @@ public struct XCFrameworkInfoPlist: Codable, Hashable, Equatable {
             // swiftlint:disable:next force_try
             path: RelativePath = try! RelativePath(validating: "relative/to/library"),
             mergeable: Bool = false,
+            platform: Platform = .iOS,
             architectures: [BinaryArchitecture] = [.i386]
         ) -> XCFrameworkInfoPlist.Library {
             XCFrameworkInfoPlist.Library(
                 identifier: identifier,
                 path: path,
                 mergeable: mergeable,
+                platform: platform,
                 architectures: architectures
             )
         }


### PR DESCRIPTION
Resolve #11

Since the XCFramework is a bundle support for multiple platforms, it‘s difficult to say which binary is the primary binary. It is better to keep the platform in the binary library and defer which to use when it is needed.