### PR TITLE
Make XCFramework's Library supported platform its own.

### DIFF
--- a/Sources/XcodeGraph/Models/XCFrameworkInfoPlist.swift
+++ b/Sources/XcodeGraph/Models/XCFrameworkInfoPlist.swift
@@ -9,6 +9,14 @@ public struct XCFrameworkInfoPlist: Codable, Hashable, Equatable {
 
     /// It represents a library inside an .xcframework
     public struct Library: Codable, Hashable, Equatable {
+        public enum Platform: String, CaseIterable, Codable {
+            case iOS = "ios"
+            case macOS = "macos"
+            case tvOS = "tvos"
+            case watchOS = "watchos"
+            case visionOS = "xros" // Note: for visionOS, the rawValue is `xros`
+        }
+
         private enum CodingKeys: String, CodingKey {
             case identifier = "LibraryIdentifier"
             case path = "LibraryPath"
@@ -31,7 +39,7 @@ public struct XCFrameworkInfoPlist: Codable, Hashable, Equatable {
         /// Declares if the library is mergeable or not
         public let mergeable: Bool
 
-        public let platform: Platform
+        public let platform: Self.Platform
 
         /// Architectures the binary is built for.
         public let architectures: [BinaryArchitecture]


### PR DESCRIPTION
As @kwridan mentioned at https://github.com/tuist/tuist/pull/6414#pullrequestreview-2150602930
> In this case the issue is that encoded (raw) values of those types are incompatible.
> 
> For example, for visionOS:
> 
> XcodeGraph.Platform: has a raw value of [visionos](https://github.com/tuist/XcodeGraph/blob/main/Sources/XcodeGraph/Models/Platform.swift#L15)
> XCFrameworkInfoPlist has
> ```
> <key>SupportedPlatform</key>
> <string>xros</string> 
> ```
> As such the Platform type can't be used directly to decode SupportedPlatform and would require an intermediate step to map from the SupportedPlatform to Platform.

We can just use its own `Platform` for XCFramework.