### PR TITLE
Add Metal Diagnostics Options to RunAction

### DIFF
--- a/Sources/XcodeGraph/Models/MetalOptions.swift
+++ b/Sources/XcodeGraph/Models/MetalOptions.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+public struct MetalOptions: Equatable, Codable {
+    public var apiValidation: Bool
+    public var shaderValidation: Bool
+    public var showGraphicsOverview: Bool
+    public var logGraphicsOverview: Bool
+
+    public init(
+        apiValidation: Bool = true,
+        shaderValidation: Bool = false,
+        showGraphicsOverview: Bool = false,
+        logGraphicsOverview: Bool = false
+    ) {
+        self.apiValidation = apiValidation
+        self.shaderValidation = shaderValidation
+        self.showGraphicsOverview = showGraphicsOverview
+        self.logGraphicsOverview = logGraphicsOverview
+    }
+}

--- a/Sources/XcodeGraph/Models/RunAction.swift
+++ b/Sources/XcodeGraph/Models/RunAction.swift
@@ -14,7 +14,7 @@ public struct RunAction: Equatable, Codable {
     public let arguments: Arguments?
     public let options: RunActionOptions
     public let diagnosticsOptions: SchemeDiagnosticsOptions
-    public let metalOptions: MetalOptions
+    public let metalOptions: MetalOptions?
     public let expandVariableFromTarget: TargetReference?
     public let launchStyle: LaunchStyle
 
@@ -31,7 +31,7 @@ public struct RunAction: Equatable, Codable {
         arguments: Arguments?,
         options: RunActionOptions = .init(),
         diagnosticsOptions: SchemeDiagnosticsOptions,
-        metalOptions: MetalOptions,
+        metalOptions: MetalOptions? = nil,
         expandVariableFromTarget: TargetReference? = nil,
         launchStyle: LaunchStyle = .automatically
     ) {

--- a/Sources/XcodeGraph/Models/RunAction.swift
+++ b/Sources/XcodeGraph/Models/RunAction.swift
@@ -14,6 +14,7 @@ public struct RunAction: Equatable, Codable {
     public let arguments: Arguments?
     public let options: RunActionOptions
     public let diagnosticsOptions: SchemeDiagnosticsOptions
+    public let metalOptions: MetalOptions
     public let expandVariableFromTarget: TargetReference?
     public let launchStyle: LaunchStyle
 
@@ -30,6 +31,7 @@ public struct RunAction: Equatable, Codable {
         arguments: Arguments?,
         options: RunActionOptions = .init(),
         diagnosticsOptions: SchemeDiagnosticsOptions,
+        metalOptions: MetalOptions,
         expandVariableFromTarget: TargetReference? = nil,
         launchStyle: LaunchStyle = .automatically
     ) {
@@ -43,6 +45,7 @@ public struct RunAction: Equatable, Codable {
         self.arguments = arguments
         self.options = options
         self.diagnosticsOptions = diagnosticsOptions
+        self.metalOptions = metalOptions
         self.expandVariableFromTarget = expandVariableFromTarget
         self.launchStyle = launchStyle
     }
@@ -65,6 +68,9 @@ public struct RunAction: Equatable, Codable {
                 mainThreadCheckerEnabled: true,
                 performanceAntipatternCheckerEnabled: true
             ),
+            metalOptions: MetalOptions = XcodeGraph.MetalOptions(
+                apiValidation: true
+            ),
             expandVariableFromTarget: TargetReference? = nil,
             launchStyle: LaunchStyle = .automatically
         ) -> RunAction {
@@ -79,6 +85,7 @@ public struct RunAction: Equatable, Codable {
                 arguments: arguments,
                 options: options,
                 diagnosticsOptions: diagnosticsOptions,
+                metalOptions: metalOptions,
                 expandVariableFromTarget: expandVariableFromTarget,
                 launchStyle: launchStyle
             )


### PR DESCRIPTION
### Short description 📝
This PR adds the configuration for Metal diagnostics, allowing the configuration of these fields using Tuist.

There will be three PRs in this repository: in tuist/tuist and tuist/XcodeProj.