### PR TITLE
Revert breaking changes

### DIFF
--- a/Sources/XcodeGraph/Graph/GraphDependency.swift
+++ b/Sources/XcodeGraph/Graph/GraphDependency.swift
@@ -5,6 +5,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
     public struct XCFramework: Hashable, CustomStringConvertible, Comparable, Codable {
         public let path: AbsolutePath
         public let infoPlist: XCFrameworkInfoPlist
+        public let primaryBinaryPath: AbsolutePath
         public let linking: BinaryLinking
         public let mergeable: Bool
         public let status: FrameworkStatus
@@ -12,6 +13,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         public init(
             path: AbsolutePath,
             infoPlist: XCFrameworkInfoPlist,
+            primaryBinaryPath: AbsolutePath,
             linking: BinaryLinking,
             mergeable: Bool,
             status: FrameworkStatus,
@@ -19,6 +21,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         ) {
             self.path = path
             self.infoPlist = infoPlist
+            self.primaryBinaryPath = primaryBinaryPath
             self.linking = linking
             self.mergeable = mergeable
             self.status = status
@@ -313,6 +316,8 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         public static func testXCFramework(
             path: AbsolutePath = AbsolutePath.root.appending(try! RelativePath(validating: "Test.xcframework")),
             infoPlist: XCFrameworkInfoPlist = .test(),
+            primaryBinaryPath: AbsolutePath = AbsolutePath.root
+                .appending(try! RelativePath(validating: "Test.xcframework/Test")),
             linking: BinaryLinking = .dynamic,
             status: FrameworkStatus = .required,
             macroPath: AbsolutePath? = nil
@@ -321,6 +326,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
                 GraphDependency.XCFramework(
                     path: path,
                     infoPlist: infoPlist,
+                    primaryBinaryPath: primaryBinaryPath,
                     linking: linking,
                     mergeable: false,
                     status: status,

--- a/Sources/XcodeGraph/Models/Metadata/XCFrameworkMetadata.swift
+++ b/Sources/XcodeGraph/Models/Metadata/XCFrameworkMetadata.swift
@@ -5,6 +5,7 @@ import Path
 public struct XCFrameworkMetadata: Equatable {
     public var path: AbsolutePath
     public var infoPlist: XCFrameworkInfoPlist
+    public var primaryBinaryPath: AbsolutePath
     public var linking: BinaryLinking
     public var mergeable: Bool
     public var status: FrameworkStatus
@@ -13,6 +14,7 @@ public struct XCFrameworkMetadata: Equatable {
     public init(
         path: AbsolutePath,
         infoPlist: XCFrameworkInfoPlist,
+        primaryBinaryPath: AbsolutePath,
         linking: BinaryLinking,
         mergeable: Bool,
         status: FrameworkStatus,
@@ -20,6 +22,7 @@ public struct XCFrameworkMetadata: Equatable {
     ) {
         self.path = path
         self.infoPlist = infoPlist
+        self.primaryBinaryPath = primaryBinaryPath
         self.linking = linking
         self.mergeable = mergeable
         self.status = status
@@ -33,6 +36,9 @@ public struct XCFrameworkMetadata: Equatable {
             // swiftlint:disable:next force_try
             path: AbsolutePath = try! AbsolutePath(validating: "/XCFrameworks/XCFramework.xcframework"),
             infoPlist: XCFrameworkInfoPlist = .test(),
+            primaryBinaryPath: AbsolutePath =
+                // swiftlint:disable:next force_try
+                try! AbsolutePath(validating: "/XCFrameworks/XCFramework.xcframework/ios-arm64/XCFramework"),
             linking: BinaryLinking = .dynamic,
             mergeable: Bool = false,
             status: FrameworkStatus = .required,
@@ -41,6 +47,7 @@ public struct XCFrameworkMetadata: Equatable {
             XCFrameworkMetadata(
                 path: path,
                 infoPlist: infoPlist,
+                primaryBinaryPath: primaryBinaryPath,
                 linking: linking,
                 mergeable: mergeable,
                 status: status,

--- a/Sources/XcodeGraph/Models/ResourceSynthesizer.swift
+++ b/Sources/XcodeGraph/Models/ResourceSynthesizer.swift
@@ -15,7 +15,6 @@ public struct ResourceSynthesizer: Equatable, Hashable, Codable {
 
     public enum Parser: String, Equatable, Hashable, Codable {
         case strings
-        case stringsCatalog
         case assets
         case plists
         case fonts


### PR DESCRIPTION
I am reverting PRs that introduced breaking changes and make it impossible to update `XcodeGraph` in `tuist` as their counterpart PRs in `tuist/tuist` have not been approved and can't be merged:
- https://github.com/tuist/XcodeGraph/pull/9 -> https://github.com/tuist/tuist/pull/6296
- https://github.com/tuist/XcodeGraph/pull/12 -> https://github.com/tuist/tuist/pull/6414