### PR TITLE
refactor: unify status enums into one linking status

### DIFF
--- a/Sources/XcodeGraph/DependenciesGraph/DependenciesGraph.swift
+++ b/Sources/XcodeGraph/DependenciesGraph/DependenciesGraph.swift
@@ -33,7 +33,7 @@ public struct DependenciesGraph: Equatable, Codable {
             name: String = "Test",
             // swiftlint:disable:next force_try
             path: AbsolutePath = AbsolutePath.root.appending(try! RelativePath(validating: "Test.xcframework")),
-            status: FrameworkStatus = .required
+            status: LinkingStatus = .required
         ) -> DependenciesGraph {
             let externalDependencies = [name: [TargetDependency.xcframework(path: path, status: status)]]
 

--- a/Sources/XcodeGraph/Graph/GraphDependency.swift
+++ b/Sources/XcodeGraph/Graph/GraphDependency.swift
@@ -8,7 +8,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         public let primaryBinaryPath: AbsolutePath
         public let linking: BinaryLinking
         public let mergeable: Bool
-        public let status: FrameworkStatus
+        public let status: LinkingStatus
 
         public init(
             path: AbsolutePath,
@@ -16,7 +16,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
             primaryBinaryPath: AbsolutePath,
             linking: BinaryLinking,
             mergeable: Bool,
-            status: FrameworkStatus,
+            status: LinkingStatus,
             macroPath _: AbsolutePath?
         ) {
             self.path = path
@@ -60,7 +60,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         bcsymbolmapPaths: [AbsolutePath],
         linking: BinaryLinking,
         architectures: [BinaryArchitecture],
-        status: FrameworkStatus
+        status: LinkingStatus
     )
 
     /// A dependency that represents a pre-compiled library.
@@ -85,7 +85,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
     case target(name: String, path: AbsolutePath)
 
     /// A dependency that represents an SDK
-    case sdk(name: String, path: AbsolutePath, status: SDKStatus, source: SDKSource)
+    case sdk(name: String, path: AbsolutePath, status: LinkingStatus, source: SDKSource)
 
     public func hash(into hasher: inout Hasher) {
         switch self {
@@ -294,7 +294,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
             bcsymbolmapPaths: [AbsolutePath] = [],
             linking: BinaryLinking = .dynamic,
             architectures: [BinaryArchitecture] = [.armv7],
-            status: FrameworkStatus = .required
+            status: LinkingStatus = .required
         ) -> GraphDependency {
             GraphDependency.framework(
                 path: path,
@@ -319,7 +319,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
             primaryBinaryPath: AbsolutePath = AbsolutePath.root
                 .appending(try! RelativePath(validating: "Test.xcframework/Test")),
             linking: BinaryLinking = .dynamic,
-            status: FrameworkStatus = .required,
+            status: LinkingStatus = .required,
             macroPath: AbsolutePath? = nil
         ) -> GraphDependency {
             .xcframework(
@@ -348,7 +348,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         public static func testSDK(
             name: String = "XCTest.framework",
             path: AbsolutePath = AbsolutePath.root.appending(try! RelativePath(validating: "XCTest.framework")),
-            status: SDKStatus = .required,
+            status: LinkingStatus = .required,
             source: SDKSource = .system
         ) -> GraphDependency {
             .sdk(

--- a/Sources/XcodeGraph/Models/Metadata/FrameworkMetadata.swift
+++ b/Sources/XcodeGraph/Models/Metadata/FrameworkMetadata.swift
@@ -9,7 +9,7 @@ public struct FrameworkMetadata: Equatable {
     public var bcsymbolmapPaths: [AbsolutePath]
     public var linking: BinaryLinking
     public var architectures: [BinaryArchitecture]
-    public var status: FrameworkStatus
+    public var status: LinkingStatus
 
     public init(
         path: AbsolutePath,
@@ -18,7 +18,7 @@ public struct FrameworkMetadata: Equatable {
         bcsymbolmapPaths: [AbsolutePath],
         linking: BinaryLinking,
         architectures: [BinaryArchitecture],
-        status: FrameworkStatus
+        status: LinkingStatus
     ) {
         self.path = path
         self.binaryPath = binaryPath
@@ -41,7 +41,7 @@ public struct FrameworkMetadata: Equatable {
             bcsymbolmapPaths: [AbsolutePath] = [],
             linking: BinaryLinking = .dynamic,
             architectures: [BinaryArchitecture] = [.arm64],
-            status: FrameworkStatus = .required
+            status: LinkingStatus = .required
         ) -> FrameworkMetadata {
             FrameworkMetadata(
                 path: path,

--- a/Sources/XcodeGraph/Models/Metadata/SystemFrameworkMetadata.swift
+++ b/Sources/XcodeGraph/Models/Metadata/SystemFrameworkMetadata.swift
@@ -5,13 +5,13 @@ import Path
 public struct SystemFrameworkMetadata: Equatable {
     public var name: String
     public var path: AbsolutePath
-    public var status: SDKStatus
+    public var status: LinkingStatus
     public var source: SDKSource
 
     public init(
         name: String,
         path: AbsolutePath,
-        status: SDKStatus,
+        status: LinkingStatus,
         source: SDKSource
     ) {
         self.name = name

--- a/Sources/XcodeGraph/Models/Metadata/XCFrameworkMetadata.swift
+++ b/Sources/XcodeGraph/Models/Metadata/XCFrameworkMetadata.swift
@@ -8,7 +8,7 @@ public struct XCFrameworkMetadata: Equatable {
     public var primaryBinaryPath: AbsolutePath
     public var linking: BinaryLinking
     public var mergeable: Bool
-    public var status: FrameworkStatus
+    public var status: LinkingStatus
     public var macroPath: AbsolutePath?
 
     public init(
@@ -17,7 +17,7 @@ public struct XCFrameworkMetadata: Equatable {
         primaryBinaryPath: AbsolutePath,
         linking: BinaryLinking,
         mergeable: Bool,
-        status: FrameworkStatus,
+        status: LinkingStatus,
         macroPath: AbsolutePath?
     ) {
         self.path = path
@@ -41,7 +41,7 @@ public struct XCFrameworkMetadata: Equatable {
                 try! AbsolutePath(validating: "/XCFrameworks/XCFramework.xcframework/ios-arm64/XCFramework"),
             linking: BinaryLinking = .dynamic,
             mergeable: Bool = false,
-            status: FrameworkStatus = .required,
+            status: LinkingStatus = .required,
             macroPath: AbsolutePath? = nil
         ) -> XCFrameworkMetadata {
             XCFrameworkMetadata(

--- a/Sources/XcodeGraph/Models/TargetDependency.swift
+++ b/Sources/XcodeGraph/Models/TargetDependency.swift
@@ -1,12 +1,7 @@
 import Foundation
 import Path
 
-public enum FrameworkStatus: String, Hashable, Codable {
-    case required
-    case optional
-}
-
-public enum SDKStatus: String, Codable {
+public enum LinkingStatus: String, Hashable, Codable {
     case required
     case optional
 }
@@ -20,8 +15,8 @@ public enum TargetDependency: Equatable, Hashable, Codable {
 
     case target(name: String, condition: PlatformCondition? = nil)
     case project(target: String, path: AbsolutePath, condition: PlatformCondition? = nil)
-    case framework(path: AbsolutePath, status: FrameworkStatus, condition: PlatformCondition? = nil)
-    case xcframework(path: AbsolutePath, status: FrameworkStatus, condition: PlatformCondition? = nil)
+    case framework(path: AbsolutePath, status: LinkingStatus, condition: PlatformCondition? = nil)
+    case xcframework(path: AbsolutePath, status: LinkingStatus, condition: PlatformCondition? = nil)
     case library(
         path: AbsolutePath,
         publicHeaders: AbsolutePath,
@@ -29,7 +24,7 @@ public enum TargetDependency: Equatable, Hashable, Codable {
         condition: PlatformCondition? = nil
     )
     case package(product: String, type: PackageType, condition: PlatformCondition? = nil)
-    case sdk(name: String, status: SDKStatus, condition: PlatformCondition? = nil)
+    case sdk(name: String, status: LinkingStatus, condition: PlatformCondition? = nil)
     case xctest
 
     public var condition: PlatformCondition? {


### PR DESCRIPTION
This is the first part of refactoring in order to support weak linking on any target in Tuist. It's either this or creating a new `TargetStatus` which doesn't seem ideal given **status** is something that can be attributed to any dependency.