### PR TITLE
feat: add support to declare actions for which a target should be built

### DIFF
--- a/.github/workflows/XcodeGraph.yml
+++ b/.github/workflows/XcodeGraph.yml
@@ -2,16 +2,16 @@ name: XcodeGraph
 on:
   push:
     branches:
-      - '**'
+      - "**"
     tags-ignore:
-      - '**'
+      - "**"
     paths:
-      - '**/*.swift'
-      - '.github/workflows/*.yml'
+      - "**/*.swift"
+      - ".github/workflows/*.yml"
   pull_request:
     paths:
-      - '**/*.swift'
-      - '.github/workflows/*.yml'
+      - "**/*.swift"
+      - ".github/workflows/*.yml"
 
 concurrency:
   group: XcodeGraph-${{ github.workflow }}-${{ github.ref }}
@@ -30,33 +30,33 @@ jobs:
           - ubuntu-22.04
           - macOS-13
         swift-version:
-          - '5.9'
+          - "5.9"
         swift-compat-ver:
-          - '5'
+          - "5"
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
-    - uses: SwiftyLab/setup-swift@latest
-      with:
-        swift-version: ${{ matrix.swift-version }}
-    # DEBUG mode
-    - name: Build with debug mode.
-      id: debug_build
-      run: swift build --configuration debug -Xswiftc -swift-version -Xswiftc ${{ matrix.swift-compat-ver }}
-      continue-on-error: true
-    - name: Retry build with debug mode if necessary
-      if: steps.debug_build.outcome == 'failure'
-      run: |
-        swift build --configuration debug -Xswiftc -swift-version -Xswiftc ${{ matrix.swift-compat-ver }}
-    # RELEASE mode
-    - name: Build with release mode.
-      id: release_build
-      run: swift build --configuration release -Xswiftc -enable-testing -Xswiftc -swift-version -Xswiftc ${{ matrix.swift-compat-ver }}
-      continue-on-error: true
-    - name: Retry build with release mode if necessary
-      if: steps.release_build.outcome == 'failure'
-      run: |
-        swift build --configuration release -Xswiftc -swift-version -Xswiftc ${{ matrix.swift-compat-ver }}
+      - uses: actions/checkout@v4
+      - uses: SwiftyLab/setup-swift@latest
+        with:
+          swift-version: ${{ matrix.swift-version }}
+      # DEBUG mode
+      - name: Build with debug mode.
+        id: debug_build
+        run: swift build --configuration debug -Xswiftc -swift-version -Xswiftc ${{ matrix.swift-compat-ver }}
+        continue-on-error: true
+      - name: Retry build with debug mode if necessary
+        if: steps.debug_build.outcome == 'failure'
+        run: |
+          swift build --configuration debug -Xswiftc -swift-version -Xswiftc ${{ matrix.swift-compat-ver }}
+      # RELEASE mode
+      - name: Build with release mode.
+        id: release_build
+        run: swift build --configuration release -Xswiftc -enable-testing -Xswiftc -swift-version -Xswiftc ${{ matrix.swift-compat-ver }}
+        continue-on-error: true
+      - name: Retry build with release mode if necessary
+        if: steps.release_build.outcome == 'failure'
+        run: |
+          swift build --configuration release -Xswiftc -swift-version -Xswiftc ${{ matrix.swift-compat-ver }}
   tuist_build:
     name: Tuist Build
     strategy:
@@ -64,9 +64,9 @@ jobs:
         os:
           - macOS-13
         swift-version:
-          - '5.9'
+          - "5.9"
         swift-compat-ver:
-          - '5'
+          - "5"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -78,6 +78,27 @@ jobs:
         run: tuist install
       - name: Build
         run: tuist build
+  tuist_test:
+    name: Tuist Test
+    strategy:
+      matrix:
+        os:
+          - macOS-13
+        swift-version:
+          - "5.9"
+        swift-compat-ver:
+          - "5"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: SwiftyLab/setup-swift@latest
+        with:
+          swift-version: ${{ matrix.swift-version }}
+      - uses: jdx/mise-action@v2
+      - name: Install dependencies
+        run: tuist install
+      - name: Build
+        run: tuist test
   lint:
     name: Lint
     strategy:
@@ -85,9 +106,9 @@ jobs:
         os:
           - macOS-13
         swift-version:
-          - '5.9'
+          - "5.9"
         swift-compat-ver:
-          - '5'
+          - "5"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/Path.git",
       "state" : {
-        "revision" : "e137d6db7a31decd77077613f5c59c745102603e",
-        "version" : "0.3.5"
+        "revision" : "bee1e910422f5c817b58dc593c50d747c4637b9c",
+        "version" : "0.3.6"
       }
     }
   ],

--- a/Sources/XcodeGraph/Models/BuildAction.swift
+++ b/Sources/XcodeGraph/Models/BuildAction.swift
@@ -2,22 +2,70 @@ import Foundation
 import Path
 
 public struct BuildAction: Equatable, Codable, Sendable {
+    /// It represents the reference to a target from a build action, along with the actions when the target
+    /// should be built.
+    public struct Target: Equatable, Codable, Sendable {
+        /// Xcode project actions when a build scheme action can build a target.
+        public enum BuildFor: Codable, CaseIterable, Sendable {
+            case running, testing, profiling, archiving, analyzing
+        }
+
+        /// The target reference.
+        public var reference: TargetReference
+
+        /// A list of Xcode actions when a target should build.
+        public var buildFor: [BuildFor]?
+
+        public init(_ reference: TargetReference, buildFor: [BuildFor]?) {
+            self.reference = reference
+            self.buildFor = buildFor
+        }
+    }
+
     // MARK: - Attributes
 
-    public var targets: [TargetReference]
+    public var targetsWithBuildFor: [Target]
+    @available(
+        *,
+        deprecated,
+        renamed: "targetsWithBuildFor",
+        message: "Use the initializer that takes targets as instances of BuildAction.Target"
+    )
+    public var targets: [TargetReference] {
+        get {
+            targetsWithBuildFor.map(\.reference)
+        }
+        set {
+            targetsWithBuildFor = newValue.map { Target($0, buildFor: nil) }
+        }
+    }
+
     public var preActions: [ExecutionAction]
     public var postActions: [ExecutionAction]
     public var runPostActionsOnFailure: Bool
 
     // MARK: - Init
 
+    @available(*, deprecated, message: "Use the initializer that takes targets as instances of BuildAction.Target")
     public init(
         targets: [TargetReference] = [],
         preActions: [ExecutionAction] = [],
         postActions: [ExecutionAction] = [],
         runPostActionsOnFailure: Bool = false
     ) {
-        self.targets = targets
+        targetsWithBuildFor = targets.map { Target($0, buildFor: nil) }
+        self.preActions = preActions
+        self.postActions = postActions
+        self.runPostActionsOnFailure = runPostActionsOnFailure
+    }
+
+    public init(
+        targetsWithBuildFor: [BuildAction.Target] = [],
+        preActions: [ExecutionAction] = [],
+        postActions: [ExecutionAction] = [],
+        runPostActionsOnFailure: Bool = false
+    ) {
+        self.targetsWithBuildFor = targetsWithBuildFor
         self.preActions = preActions
         self.postActions = postActions
         self.runPostActionsOnFailure = runPostActionsOnFailure

--- a/Sources/XcodeGraph/Models/BuildAction.swift
+++ b/Sources/XcodeGraph/Models/BuildAction.swift
@@ -67,16 +67,7 @@ public struct BuildAction: Equatable, Codable, Sendable {
     extension BuildAction {
         public static func test(
             // swiftlint:disable:next force_try
-            targets: [TargetReference] = [TargetReference(projectPath: try! AbsolutePath(validating: "/Project"), name: "App")],
-            preActions: [ExecutionAction] = [],
-            postActions: [ExecutionAction] = []
-        ) -> BuildAction {
-            BuildAction(targets: targets.map { Target($0) }, preActions: preActions, postActions: postActions)
-        }
-
-        public static func test(
-            // swiftlint:disable:next force_try
-            targets: [Target] = [],
+            targets: [BuildAction.Target] = [],
             preActions: [ExecutionAction] = [],
             postActions: [ExecutionAction] = []
         ) -> BuildAction {

--- a/Sources/XcodeGraph/Models/BuildAction.swift
+++ b/Sources/XcodeGraph/Models/BuildAction.swift
@@ -16,7 +16,7 @@ public struct BuildAction: Equatable, Codable, Sendable {
         /// A list of Xcode actions when a target should build.
         public var buildFor: [BuildFor]?
 
-        public init(_ reference: TargetReference, buildFor: [BuildFor]?) {
+        public init(_ reference: TargetReference, buildFor: [BuildFor]? = nil) {
             self.reference = reference
             self.buildFor = buildFor
         }
@@ -24,22 +24,7 @@ public struct BuildAction: Equatable, Codable, Sendable {
 
     // MARK: - Attributes
 
-    public var targetsWithBuildFor: [Target]
-    @available(
-        *,
-        deprecated,
-        renamed: "targetsWithBuildFor",
-        message: "Use the initializer that takes targets as instances of BuildAction.Target"
-    )
-    public var targets: [TargetReference] {
-        get {
-            targetsWithBuildFor.map(\.reference)
-        }
-        set {
-            targetsWithBuildFor = newValue.map { Target($0, buildFor: nil) }
-        }
-    }
-
+    public var targets: [Target]
     public var preActions: [ExecutionAction]
     public var postActions: [ExecutionAction]
     public var runPostActionsOnFailure: Bool
@@ -53,19 +38,19 @@ public struct BuildAction: Equatable, Codable, Sendable {
         postActions: [ExecutionAction] = [],
         runPostActionsOnFailure: Bool = false
     ) {
-        targetsWithBuildFor = targets.map { Target($0, buildFor: nil) }
+        self.targets = targets.map { Target($0, buildFor: nil) }
         self.preActions = preActions
         self.postActions = postActions
         self.runPostActionsOnFailure = runPostActionsOnFailure
     }
 
     public init(
-        targetsWithBuildFor: [BuildAction.Target] = [],
+        targets: [BuildAction.Target] = [],
         preActions: [ExecutionAction] = [],
         postActions: [ExecutionAction] = [],
         runPostActionsOnFailure: Bool = false
     ) {
-        self.targetsWithBuildFor = targetsWithBuildFor
+        self.targets = targets
         self.preActions = preActions
         self.postActions = postActions
         self.runPostActionsOnFailure = runPostActionsOnFailure
@@ -73,10 +58,25 @@ public struct BuildAction: Equatable, Codable, Sendable {
 }
 
 #if DEBUG
+    extension BuildAction.Target {
+        public static func test(_ reference: TargetReference = TargetReference.test(), buildFor: [BuildFor]? = nil) -> Self {
+            return Self(reference, buildFor: buildFor)
+        }
+    }
+
     extension BuildAction {
         public static func test(
             // swiftlint:disable:next force_try
             targets: [TargetReference] = [TargetReference(projectPath: try! AbsolutePath(validating: "/Project"), name: "App")],
+            preActions: [ExecutionAction] = [],
+            postActions: [ExecutionAction] = []
+        ) -> BuildAction {
+            BuildAction(targets: targets.map { Target($0) }, preActions: preActions, postActions: postActions)
+        }
+
+        public static func test(
+            // swiftlint:disable:next force_try
+            targets: [Target] = [],
             preActions: [ExecutionAction] = [],
             postActions: [ExecutionAction] = []
         ) -> BuildAction {

--- a/Sources/XcodeGraph/Models/BuildAction.swift
+++ b/Sources/XcodeGraph/Models/BuildAction.swift
@@ -31,7 +31,10 @@ public struct BuildAction: Equatable, Codable, Sendable {
 
     // MARK: - Init
 
-    @available(*, deprecated, message: "Use the initializer that takes targets as instances of BuildAction.Target")
+    @available(
+        *, deprecated,
+        message: "Use the initializer that takes targets as instances of BuildAction.Target"
+    )
     public init(
         targets: [TargetReference] = [],
         preActions: [ExecutionAction] = [],
@@ -59,14 +62,15 @@ public struct BuildAction: Equatable, Codable, Sendable {
 
 #if DEBUG
     extension BuildAction.Target {
-        public static func test(_ reference: TargetReference = TargetReference.test(), buildFor: [BuildFor]? = nil) -> Self {
+        public static func test(
+            _ reference: TargetReference = TargetReference.test(), buildFor: [BuildFor]? = nil
+        ) -> Self {
             return Self(reference, buildFor: buildFor)
         }
     }
 
     extension BuildAction {
         public static func test(
-            // swiftlint:disable:next force_try
             targets: [BuildAction.Target] = [],
             preActions: [ExecutionAction] = [],
             postActions: [ExecutionAction] = []

--- a/Sources/XcodeGraph/Models/BuildAction.swift
+++ b/Sources/XcodeGraph/Models/BuildAction.swift
@@ -45,7 +45,7 @@ public struct BuildAction: Equatable, Codable, Sendable {
     }
 
     public init(
-        targets: [BuildAction.Target] = [],
+        targets: [BuildAction.Target],
         preActions: [ExecutionAction] = [],
         postActions: [ExecutionAction] = [],
         runPostActionsOnFailure: Bool = false

--- a/Sources/XcodeGraph/Models/TargetReference.swift
+++ b/Sources/XcodeGraph/Models/TargetReference.swift
@@ -14,6 +14,7 @@ public struct TargetReference: Hashable, Codable, Sendable {
 #if DEBUG
     extension TargetReference {
         public static func test(
+            // swiftlint:disable:next force_try
             projectPath: AbsolutePath = try! AbsolutePath(validating: "/Project"),
             name: String = "TestTarget"
         ) -> Self {

--- a/Sources/XcodeGraph/Models/TargetReference.swift
+++ b/Sources/XcodeGraph/Models/TargetReference.swift
@@ -10,3 +10,14 @@ public struct TargetReference: Hashable, Codable, Sendable {
         self.name = name
     }
 }
+
+#if DEBUG
+    extension TargetReference {
+        public static func test(
+            projectPath: AbsolutePath = try! AbsolutePath(validating: "/Project"),
+            name: String = "TestTarget"
+        ) -> Self {
+            return TargetReference(projectPath: projectPath, name: name)
+        }
+    }
+#endif

--- a/Sources/XcodeGraph/Models/Workspace.swift
+++ b/Sources/XcodeGraph/Models/Workspace.swift
@@ -111,7 +111,7 @@ extension Workspace {
 
                 // having empty `codeCoverageTargets` means that we should gather code coverage for all build targets
                 if schemeCoverageTargets.isEmpty, let buildAction = scheme.buildAction {
-                    resultTargets.formUnion(buildAction.targets)
+                    resultTargets.formUnion(buildAction.targets.map(\.reference))
                 } else {
                     resultTargets.formUnion(schemeCoverageTargets)
                 }

--- a/Tests/XcodeGraphTests/Models/BuildActionTests.swift
+++ b/Tests/XcodeGraphTests/Models/BuildActionTests.swift
@@ -8,11 +8,11 @@ final class BuildActionTests: XCTestCase {
     func test_codable() {
         // Given
         let subject = BuildAction(
-            targets: [
-                .init(
+            targetsWithBuildFor: [
+                BuildAction.Target(TargetReference(
                     projectPath: try! AbsolutePath(validating: "/path/to/project"),
                     name: "name"
-                ),
+                ), buildFor: [.running]),
             ],
             preActions: [
                 .init(

--- a/Tests/XcodeGraphTests/Models/BuildActionTests.swift
+++ b/Tests/XcodeGraphTests/Models/BuildActionTests.swift
@@ -8,7 +8,7 @@ final class BuildActionTests: XCTestCase {
     func test_codable() {
         // Given
         let subject = BuildAction(
-            targetsWithBuildFor: [
+            targets: [
                 BuildAction.Target(TargetReference(
                     projectPath: try! AbsolutePath(validating: "/path/to/project"),
                     name: "name"

--- a/Tests/XcodeGraphTests/Models/TargetTests.swift
+++ b/Tests/XcodeGraphTests/Models/TargetTests.swift
@@ -14,25 +14,8 @@ final class TargetTests: XCTestCase {
 
     func test_validSourceExtensions() {
         XCTAssertEqual(
-            Target.validSourceExtensions,
-            [
-                "m",
-                "swift",
-                "mm",
-                "cpp",
-                "cc",
-                "c",
-                "d",
-                "s",
-                "intentdefinition",
-                "xcmappingmodel",
-                "metal",
-                "mlmodel",
-                "docc",
-                "playground",
-                "rcproject",
-                "mlpackage",
-            ]
+            Target.validSourceExtensions.sorted(),
+            ["c", "cc", "cpp", "d", "intentdefinition", "m", "metal", "mlmodel", "mm", "s", "swift"]
         )
     }
 


### PR DESCRIPTION
I'm making some changes necessary to finish up [this PR](https://github.com/tuist/tuist/pull/6046). Note that I made the changes so we don't break downstream users of `tuist/xcodegraph`. Although we are the only ones now, I think it's good to start building the habit of not breaking this dependency.