### PR TITLE
fix: missing baseDebug in Settings.with

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/Path.git",
       "state" : {
-        "revision" : "e137d6db7a31decd77077613f5c59c745102603e",
-        "version" : "0.3.5"
+        "revision" : "bee1e910422f5c817b58dc593c50d747c4637b9c",
+        "version" : "0.3.6"
       }
     }
   ],

--- a/Sources/XcodeGraph/Models/Settings.swift
+++ b/Sources/XcodeGraph/Models/Settings.swift
@@ -145,6 +145,7 @@ public struct Settings: Equatable, Codable, Sendable {
     public func with(base: SettingsDictionary) -> Settings {
         .init(
             base: base,
+            baseDebug: baseDebug,
             configurations: configurations,
             defaultSettings: defaultSettings
         )


### PR DESCRIPTION
When working on https://github.com/tuist/tuist/pull/6757, I noticed the `Settings.with` mapper is missing a `baseDebug` property.