### PR TITLE
fix: add c++ to valid source extensions

### DIFF
--- a/Sources/XcodeGraph/Models/Target.swift
+++ b/Sources/XcodeGraph/Models/Target.swift
@@ -11,7 +11,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
         "playground", "rcproject", "mlpackage", "docc", "xcmappingmodel",
     ]
     public static let validSourceExtensions: [String] = [
-        "m", "swift", "mm", "cpp", "cc", "c", "d", "s", "intentdefinition", "metal", "mlmodel",
+        "m", "swift", "mm", "cpp", "c++", "cc", "c", "d", "s", "intentdefinition", "metal", "mlmodel",
     ]
     public static let validFolderExtensions: [String] = [
         "framework", "bundle", "app", "xcassets", "appiconset", "scnassets",

--- a/Tests/XcodeGraphTests/Models/TargetTests.swift
+++ b/Tests/XcodeGraphTests/Models/TargetTests.swift
@@ -20,6 +20,7 @@ final class TargetTests: XCTestCase {
                 "swift",
                 "mm",
                 "cpp",
+                "c++",
                 "cc",
                 "c",
                 "d",


### PR DESCRIPTION
As per title, this is needed to compile [capnproto](https://github.com/capnproto/capnproto) as a dependency with Tuist.