### PR TITLE
feat: add .none linking status

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/Path.git",
       "state" : {
-        "revision" : "bee1e910422f5c817b58dc593c50d747c4637b9c",
-        "version" : "0.3.6"
+        "revision" : "7c74ac435e03a927c3a73134c48b61e60221abcb",
+        "version" : "0.3.8"
       }
     }
   ],

--- a/Sources/XcodeGraph/Models/TargetDependency.swift
+++ b/Sources/XcodeGraph/Models/TargetDependency.swift
@@ -4,6 +4,7 @@ import Path
 public enum LinkingStatus: String, Hashable, Codable, Sendable {
     case required
     case optional
+    case none
 }
 
 public enum TargetDependency: Equatable, Hashable, Codable, Sendable {


### PR DESCRIPTION
Adds `.none` type to `LinkingStatus` to indicate that no linking should be done on a target dependency.

This is a first step to solve https://github.com/tuist/tuist/issues/6751

Unblocks https://github.com/tuist/tuist/pull/6838