### PR TITLE
feat: expose findImplicitDependencies property on BuildAction

### DIFF
--- a/Sources/XcodeGraph/Models/BuildAction.swift
+++ b/Sources/XcodeGraph/Models/BuildAction.swift
@@ -8,6 +8,7 @@ public struct BuildAction: Equatable, Codable, Sendable {
     public var preActions: [ExecutionAction]
     public var postActions: [ExecutionAction]
     public var runPostActionsOnFailure: Bool
+    public var buildImplicitDependencies: Bool
 
     // MARK: - Init
 
@@ -15,12 +16,14 @@ public struct BuildAction: Equatable, Codable, Sendable {
         targets: [TargetReference] = [],
         preActions: [ExecutionAction] = [],
         postActions: [ExecutionAction] = [],
-        runPostActionsOnFailure: Bool = false
+        runPostActionsOnFailure: Bool = false,
+        buildImplicitDependencies: Bool = true
     ) {
         self.targets = targets
         self.preActions = preActions
         self.postActions = postActions
         self.runPostActionsOnFailure = runPostActionsOnFailure
+        self.buildImplicitDependencies = buildImplicitDependencies
     }
 }
 

--- a/Sources/XcodeGraph/Models/BuildAction.swift
+++ b/Sources/XcodeGraph/Models/BuildAction.swift
@@ -8,7 +8,7 @@ public struct BuildAction: Equatable, Codable, Sendable {
     public var preActions: [ExecutionAction]
     public var postActions: [ExecutionAction]
     public var runPostActionsOnFailure: Bool
-    public var buildImplicitDependencies: Bool
+    public var findImplicitDependencies: Bool
 
     // MARK: - Init
 
@@ -17,13 +17,13 @@ public struct BuildAction: Equatable, Codable, Sendable {
         preActions: [ExecutionAction] = [],
         postActions: [ExecutionAction] = [],
         runPostActionsOnFailure: Bool = false,
-        buildImplicitDependencies: Bool = true
+        findImplicitDependencies: Bool = true
     ) {
         self.targets = targets
         self.preActions = preActions
         self.postActions = postActions
         self.runPostActionsOnFailure = runPostActionsOnFailure
-        self.buildImplicitDependencies = buildImplicitDependencies
+        self.findImplicitDependencies = findImplicitDependencies
     }
 }
 


### PR DESCRIPTION
This PR exposes a `buildImplicitDependencies` property on `BuildAction` in order to enable the possibility in tuist to control the `Find Implicit Dependencies` in build actions. I used `true` as the default to not break any upstream changes since it is the default for Xcode as well. 

The reason why I think it's a useful addition is that in the official tuist documentation it is recommended to disable this setting(https://docs.tuist.io/en/guides/develop/projects/cost-of-convenience#find-implicit-dependencies-in-schemes) but there seems to be no way through tuist to do it.

Let me know what you think about this addition. In case you like the idea I would also drive the implementation in the tuist CLI afterwards. 