### PR TITLE
[feat] Supersede `Project.external` with `Project.type` 

### DIFF
--- a/.github/workflows/XcodeGraph.yml
+++ b/.github/workflows/XcodeGraph.yml
@@ -75,7 +75,7 @@ jobs:
           swift-version: ${{ matrix.swift-version }}
       - uses: jdx/mise-action@v2
         with:
-          version: v2024.11.8
+          version: 2024.11.8
       - name: Install dependencies
         run: tuist install
       - name: Build
@@ -98,6 +98,6 @@ jobs:
           swift-version: ${{ matrix.swift-version }}
       - uses: jdx/mise-action@v2
         with:
-          version: v2024.11.8
+          version: 2024.11.8
       - name: Lint
         run: mise run lint

--- a/.github/workflows/XcodeGraph.yml
+++ b/.github/workflows/XcodeGraph.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - macos-15
+          - macos-14
         swift-version:
           - "5.9"
         swift-compat-ver:
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-15
+          - macos-14
         swift-version:
           - "5.9"
         swift-compat-ver:
@@ -85,7 +85,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-15
+          - macos-14
         swift-version:
           - "5.9"
         swift-compat-ver:

--- a/.github/workflows/XcodeGraph.yml
+++ b/.github/workflows/XcodeGraph.yml
@@ -19,7 +19,7 @@ concurrency:
 
 env:
   MISE_EXPERIMENTAL: 1
-  TUIST_CONFIG_CLOUD_TOKEN: ${{ secrets.TUIST_CONFIG_CLOUD_TOKEN }}
+  TUIST_CONFIG_TOKEN: ${{ secrets.TUIST_CONFIG_CLOUD_TOKEN }}
 
 jobs:
   spm_build:
@@ -28,7 +28,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - macOS-13
+          - macos-15
         swift-version:
           - "5.9"
         swift-compat-ver:
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macOS-13
+          - macos-15
         swift-version:
           - "5.9"
         swift-compat-ver:
@@ -85,7 +85,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macOS-13
+          - macos-15
         swift-version:
           - "5.9"
         swift-compat-ver:

--- a/.github/workflows/XcodeGraph.yml
+++ b/.github/workflows/XcodeGraph.yml
@@ -2,16 +2,16 @@ name: XcodeGraph
 on:
   push:
     branches:
-      - '**'
+      - "**"
     tags-ignore:
-      - '**'
+      - "**"
     paths:
-      - '**/*.swift'
-      - '.github/workflows/*.yml'
+      - "**/*.swift"
+      - ".github/workflows/*.yml"
   pull_request:
     paths:
-      - '**/*.swift'
-      - '.github/workflows/*.yml'
+      - "**/*.swift"
+      - ".github/workflows/*.yml"
 
 concurrency:
   group: XcodeGraph-${{ github.workflow }}-${{ github.ref }}
@@ -30,33 +30,33 @@ jobs:
           - ubuntu-22.04
           - macOS-13
         swift-version:
-          - '5.9'
+          - "5.9"
         swift-compat-ver:
-          - '5'
+          - "5"
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
-    - uses: SwiftyLab/setup-swift@latest
-      with:
-        swift-version: ${{ matrix.swift-version }}
-    # DEBUG mode
-    - name: Build with debug mode.
-      id: debug_build
-      run: swift build --configuration debug -Xswiftc -swift-version -Xswiftc ${{ matrix.swift-compat-ver }}
-      continue-on-error: true
-    - name: Retry build with debug mode if necessary
-      if: steps.debug_build.outcome == 'failure'
-      run: |
-        swift build --configuration debug -Xswiftc -swift-version -Xswiftc ${{ matrix.swift-compat-ver }}
-    # RELEASE mode
-    - name: Build with release mode.
-      id: release_build
-      run: swift build --configuration release -Xswiftc -enable-testing -Xswiftc -swift-version -Xswiftc ${{ matrix.swift-compat-ver }}
-      continue-on-error: true
-    - name: Retry build with release mode if necessary
-      if: steps.release_build.outcome == 'failure'
-      run: |
-        swift build --configuration release -Xswiftc -swift-version -Xswiftc ${{ matrix.swift-compat-ver }}
+      - uses: actions/checkout@v4
+      - uses: SwiftyLab/setup-swift@latest
+        with:
+          swift-version: ${{ matrix.swift-version }}
+      # DEBUG mode
+      - name: Build with debug mode.
+        id: debug_build
+        run: swift build --configuration debug -Xswiftc -swift-version -Xswiftc ${{ matrix.swift-compat-ver }}
+        continue-on-error: true
+      - name: Retry build with debug mode if necessary
+        if: steps.debug_build.outcome == 'failure'
+        run: |
+          swift build --configuration debug -Xswiftc -swift-version -Xswiftc ${{ matrix.swift-compat-ver }}
+      # RELEASE mode
+      - name: Build with release mode.
+        id: release_build
+        run: swift build --configuration release -Xswiftc -enable-testing -Xswiftc -swift-version -Xswiftc ${{ matrix.swift-compat-ver }}
+        continue-on-error: true
+      - name: Retry build with release mode if necessary
+        if: steps.release_build.outcome == 'failure'
+        run: |
+          swift build --configuration release -Xswiftc -swift-version -Xswiftc ${{ matrix.swift-compat-ver }}
   tuist_build:
     name: Tuist Build
     strategy:
@@ -64,9 +64,9 @@ jobs:
         os:
           - macOS-13
         swift-version:
-          - '5.9'
+          - "5.9"
         swift-compat-ver:
-          - '5'
+          - "5"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -74,6 +74,8 @@ jobs:
         with:
           swift-version: ${{ matrix.swift-version }}
       - uses: jdx/mise-action@v2
+        with:
+          version: v2024.11.8
       - name: Install dependencies
         run: tuist install
       - name: Build
@@ -85,9 +87,9 @@ jobs:
         os:
           - macOS-13
         swift-version:
-          - '5.9'
+          - "5.9"
         swift-compat-ver:
-          - '5'
+          - "5"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -95,5 +97,7 @@ jobs:
         with:
           swift-version: ${{ matrix.swift-version }}
       - uses: jdx/mise-action@v2
+        with:
+          version: v2024.11.8
       - name: Lint
         run: mise run lint

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -4,12 +4,12 @@ on:
     branches:
       - main
     paths:
-      - '**/*.swift'
-      - '.github/workflows/*.yml'
+      - "**/*.swift"
+      - ".github/workflows/*.yml"
   pull_request:
     paths:
-      - '**/*.swift'
-      - '.github/workflows/*.yml'
+      - "**/*.swift"
+      - ".github/workflows/*.yml"
 
 concurrency:
   group: Cache-${{ github.workflow }}-${{ github.ref }}
@@ -18,7 +18,7 @@ concurrency:
 env:
   MISE_EXPERIMENTAL: 1
   TUIST_CONFIG_CLOUD_TOKEN: ${{ secrets.TUIST_CONFIG_CLOUD_TOKEN }}
-  
+
 jobs:
   warm:
     name: Warm
@@ -27,9 +27,9 @@ jobs:
         os:
           - macOS-13
         swift-version:
-          - '5.9'
+          - "5.9"
         swift-compat-ver:
-          - '5'
+          - "5"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -37,6 +37,8 @@ jobs:
         with:
           swift-version: ${{ matrix.swift-version }}
       - uses: jdx/mise-action@v2
+        with:
+          version: v2024.11.8
       - name: Install dependencies
         run: tuist install
       - name: Build

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -17,7 +17,7 @@ concurrency:
 
 env:
   MISE_EXPERIMENTAL: 1
-  TUIST_CONFIG_CLOUD_TOKEN: ${{ secrets.TUIST_CONFIG_CLOUD_TOKEN }}
+  TUIST_CONFIG_TOKEN: ${{ secrets.TUIST_CONFIG_CLOUD_TOKEN }}
 
 jobs:
   warm:
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macOS-13
+          - macOS-15
         swift-version:
           - "5.9"
         swift-compat-ver:

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -38,7 +38,7 @@ jobs:
           swift-version: ${{ matrix.swift-version }}
       - uses: jdx/mise-action@v2
         with:
-          version: v2024.11.8
+          version: 2024.11.8
       - name: Install dependencies
         run: tuist install
       - name: Build

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macOS-15
+          - macOS-14
         swift-version:
           - "5.9"
         swift-compat-ver:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: jdx/mise-action@v2
         with:
           experimental: true
-          version: v2024.11.8
+          version: 2024.11.8
       - name: Check if there are releasable changes
         id: is-releasable
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: jdx/mise-action@v2
         with:
           experimental: true
+          version: v2024.11.8
       - name: Check if there are releasable changes
         id: is-releasable
         run: |

--- a/.mise.toml
+++ b/.mise.toml
@@ -2,4 +2,4 @@
 tuist = "4.34.0"
 swiftlint = "0.54.0"
 swiftformat = "0.53.3"
-"git-cliff" = "2.4.0"
+"git-cliff" = "2.6.1"

--- a/Sources/XcodeGraph/Graph/GraphTarget.swift
+++ b/Sources/XcodeGraph/Graph/GraphTarget.swift
@@ -37,7 +37,7 @@ public struct GraphTarget: Equatable, Hashable, Comparable, CustomDebugStringCon
         public static func test(
             path: AbsolutePath = .root,
             target: Target = .test(),
-            project: Project = .test()
+            project: Project = .test(type: .local)
         ) -> GraphTarget {
             GraphTarget(
                 path: path,


### PR DESCRIPTION
As part of [debugging this issue](https://github.com/tuist/tuist/issues/7018), which we couldn't reproduce consistently (e.g., its behavior changes throughout terminal types), @fortmarek and I had the idea of skipping the hashing of external dependencies, since their hash can be obtained from the lock file. 
To achieve this, I'm introducing a new attribute, `Project.type`, which supersedes `Project.external`. This attribute can then include a hash when declaring a projects external. The hashing logic can then consider this to skip the hashing altogether. Thanks to this, we'll improve our performance. 

> [!NOTE]
> This doesn't mitigate the issue, but since it always happens with the same external dependency, we won't run into it. 