### PR TITLE
fix: invocation of Project.test() without specified ProjectType should use new method

### DIFF
--- a/Sources/XcodeGraph/Models/Project.swift
+++ b/Sources/XcodeGraph/Models/Project.swift
@@ -267,7 +267,7 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
             additionalFiles: [FileElement] = [],
             resourceSynthesizers: [ResourceSynthesizer] = [],
             lastUpgradeCheck: Version? = nil,
-            isExternal: Bool = false
+            isExternal: Bool
         ) -> Project {
             Project(
                 path: path,
@@ -312,7 +312,7 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
             additionalFiles: [FileElement] = [],
             resourceSynthesizers: [ResourceSynthesizer] = [],
             lastUpgradeCheck: Version? = nil,
-            type: ProjectType
+            type: ProjectType = .local
         ) -> Project {
             Project(
                 path: path,


### PR DESCRIPTION
When we use `Project.test()`, it should automatically use the non-deprecated method. We shouldn't require specifying `projectType` as that defeats the purpose of `test()` where you specify only properties you need in a specific test.

The only time we should give a deprecation warning is when the consumers explicitly use the `isExternal` in the `Project.test()` invocation.