### PR TITLE
fix: overlay platform-specific settings when the value does not exist

### DIFF
--- a/Sources/XcodeGraph/Extensions/SettingsDictionary+Extras.swift
+++ b/Sources/XcodeGraph/Extensions/SettingsDictionary+Extras.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+extension SettingsDictionary {
+    /// Overlays a SettingsDictionary by adding a `[sdk=<sdk>*]` qualifier
+    /// e.g. for a multiplatform target
+    ///  `LD_RUNPATH_SEARCH_PATHS = @executable_path/Frameworks`
+    ///  `LD_RUNPATH_SEARCH_PATHS[sdk=macosx*] = @executable_path/../Frameworks`
+    public mutating func overlay(
+        with other: SettingsDictionary,
+        for platform: Platform
+    ) {
+        for (key, newValue) in other where self[key] != newValue {
+            let newKey = "\(key)[sdk=\(platform.xcodeSdkRoot)*]"
+            self[newKey] = newValue
+            if platform.hasSimulators, let simulatorSDK = platform.xcodeSimulatorSDK {
+                let newKey = "\(key)[sdk=\(simulatorSDK)*]"
+                self[newKey] = newValue
+            }
+        }
+    }
+
+    /// Combines two `SettingsDictionary`. Instead of overriding values for a duplicate key, it combines them.
+    public func combine(with settings: SettingsDictionary) -> SettingsDictionary {
+        merging(settings, uniquingKeysWith: { oldValue, newValue in
+            let newValues: [String]
+            switch newValue {
+            case let .string(value):
+                newValues = [value]
+            case let .array(values):
+                newValues = values
+            }
+            switch oldValue {
+            case let .array(values):
+                return .array(values + newValues)
+            case let .string(value):
+                return .array(value.split(separator: " ").map(String.init) + newValues)
+            }
+        })
+    }
+}

--- a/Sources/XcodeGraph/Models/Settings.swift
+++ b/Sources/XcodeGraph/Models/Settings.swift
@@ -30,49 +30,6 @@ public enum SettingValue: ExpressibleByStringInterpolation, ExpressibleByStringL
     }
 }
 
-extension SettingsDictionary {
-    /// Overlays a SettingsDictionary by adding a `[sdk=<sdk>*]` qualifier
-    /// e.g. for a multiplatform target
-    ///  `LD_RUNPATH_SEARCH_PATHS = @executable_path/Frameworks`
-    ///  `LD_RUNPATH_SEARCH_PATHS[sdk=macosx*] = @executable_path/../Frameworks`
-    public mutating func overlay(
-        with other: SettingsDictionary,
-        for platform: Platform
-    ) {
-        for (key, newValue) in other {
-            if self[key] == nil {
-                self[key] = newValue
-            } else if self[key] != newValue {
-                let newKey = "\(key)[sdk=\(platform.xcodeSdkRoot)*]"
-                self[newKey] = newValue
-                if platform.hasSimulators, let simulatorSDK = platform.xcodeSimulatorSDK {
-                    let newKey = "\(key)[sdk=\(simulatorSDK)*]"
-                    self[newKey] = newValue
-                }
-            }
-        }
-    }
-
-    /// Combines two `SettingsDictionary`. Instead of overriding values for a duplicate key, it combines them.
-    public func combine(with settings: SettingsDictionary) -> SettingsDictionary {
-        merging(settings, uniquingKeysWith: { oldValue, newValue in
-            let newValues: [String]
-            switch newValue {
-            case let .string(value):
-                newValues = [value]
-            case let .array(values):
-                newValues = values
-            }
-            switch oldValue {
-            case let .array(values):
-                return .array(values + newValues)
-            case let .string(value):
-                return .array(value.split(separator: " ").map(String.init) + newValues)
-            }
-        })
-    }
-}
-
 public struct Configuration: Equatable, Codable, Sendable {
     // MARK: - Attributes
 

--- a/Tests/XcodeGraphTests/Extensions/SettingsDictionary+ExtrasTests.swift
+++ b/Tests/XcodeGraphTests/Extensions/SettingsDictionary+ExtrasTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import XCTest
+
+@testable import XcodeGraph
+
+final class SettingsDictionaryExtrasTest: XCTestCase {
+    func testOverlay_addsPlatformSpecifierWhenSettingsDiffer() {
+        // Given
+        var settings: [String: SettingValue] = [
+            "A": "a value",
+            "B": "b value",
+        ]
+
+        // When
+        settings.overlay(with: [
+            "A": "overlayed value",
+            "B": "b value",
+            "C": "c value",
+        ], for: .macOS)
+
+        // Then
+        XCTAssertEqual(settings, [
+            "A[sdk=macosx*]": "overlayed value",
+            "A": "a value",
+            "B": "b value",
+            "C[sdk=macosx*]": "c value",
+        ])
+    }
+}


### PR DESCRIPTION
If the `SettingsDictionary` does _not_ include a given key and we run `overlay(with: ["SETTINGS_KEY": "value"], for: .visionOS)`, the resulting settings should still include the platform specifiers:
```
[
  "SETTINGS_KEY[sdk=xros*]": "value"
]
```