### PR TITLE
feat: supportsResources returns true if product is staticFramework

### DIFF
--- a/Sources/XcodeGraph/Models/Target.swift
+++ b/Sources/XcodeGraph/Models/Target.swift
@@ -128,12 +128,12 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
 
     /// Returns whether a target is exclusive to a single platform
     public func isExclusiveTo(_ platform: Platform) -> Bool {
-        destinations.map(\.platform).allSatisfy { $0 == platform }
+        destinations.allSatisfy { $0.platform == platform }
     }
 
     /// Returns whether a target supports a platform
     public func supports(_ platform: Platform) -> Bool {
-        destinations.map(\.platform).contains(platform)
+        destinations.contains { $0.platform == platform }
     }
 
     /// List of platforms this target deploys to
@@ -209,6 +209,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
         switch product {
         case .app,
              .framework,
+             .staticFramework,
              .unitTests,
              .uiTests,
              .bundle,
@@ -227,7 +228,6 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
              .macro,
              .dynamicLibrary,
              .staticLibrary,
-             .staticFramework,
              .xpc:
             return false
         }
@@ -239,10 +239,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
 
     /// Returns true if the target is an AppClip
     public var isAppClip: Bool {
-        if case .appClip = product {
-            return true
-        }
-        return false
+        product == .appClip
     }
 
     /// Determines if the target is an embeddable watch application


### PR DESCRIPTION
Needed for tuist/tuist#7006

`Target.supportsResources` returns `true` if `Target.product == .staticFramework`.