### PR TITLE
fix: replace `TargetMetadata.isLocal` with `Target.type` enum

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,13 @@ var targets: [Target] = [
             .enableExperimentalFeature("StrictConcurrency"),
         ]
     ),
+    .testTarget(
+        name: "XcodeGraphTests",
+        dependencies: [.target(name: "XcodeGraph")],
+        swiftSettings: [
+            .enableExperimentalFeature("StrictConcurrency"),
+        ]
+    ),
 ]
 
 let package = Package(

--- a/Sources/XcodeGraph/Models/Metadata/TargetMetadata.swift
+++ b/Sources/XcodeGraph/Models/Metadata/TargetMetadata.swift
@@ -4,23 +4,15 @@ public struct TargetMetadata: Codable, Equatable, Sendable {
     /// Some Tuist features can leverage that information for doing things like filtering.
     public var tags: Set<String>
 
-    /// Projects can be external or not, which means they are declared or not using the Tuist Projects' DSL
-    /// and the targets of those projects can fall into two categories:
-    ///   - Local:  They've been linked from a local directory (e.g., a local package)
-    ///   - Remote: They've been resolved and pulled by a package manager (e.g. SPM)
-    public var isLocal: Bool
-
     @available(*, deprecated, renamed: "metadata(tags:)", message: "Use the static 'metadata' initializer instead")
     public init(
         tags: Set<String>
     ) {
         self.tags = tags
-        isLocal = true
     }
 
-    init(tags: Set<String>, isLocal: Bool) {
+    init(tags: Set<String>, isLocal _: Bool) {
         self.tags = tags
-        self.isLocal = isLocal
     }
 
     public static func metadata(tags: Set<String> = Set(), isLocal: Bool = true) -> TargetMetadata {
@@ -31,12 +23,10 @@ public struct TargetMetadata: Codable, Equatable, Sendable {
 #if DEBUG
     extension TargetMetadata {
         public static func test(
-            tags: Set<String> = [],
-            isLocal: Bool = true
+            tags: Set<String> = []
         ) -> TargetMetadata {
             TargetMetadata.metadata(
-                tags: tags,
-                isLocal: isLocal
+                tags: tags
             )
         }
     }

--- a/Sources/XcodeGraph/Models/Target.swift
+++ b/Sources/XcodeGraph/Models/Target.swift
@@ -50,6 +50,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
     public let mergeable: Bool
     public let onDemandResourcesTags: OnDemandResourcesTags?
     public let metadata: TargetMetadata
+    public let type: TargetType
 
     // MARK: - Init
 
@@ -81,7 +82,8 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
         mergedBinaryType: MergedBinaryType = .disabled,
         mergeable: Bool = false,
         onDemandResourcesTags: OnDemandResourcesTags? = nil,
-        metadata: TargetMetadata = .init(tags: [])
+        metadata: TargetMetadata = .metadata(tags: []),
+        type: TargetType = .local
     ) {
         self.name = name
         self.product = product
@@ -111,6 +113,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
         self.mergeable = mergeable
         self.onDemandResourcesTags = onDemandResourcesTags
         self.metadata = metadata
+        self.type = type
     }
 
     /// Given a target name, it obtains the product name by turning "-" characters into "_" and "/" into "_"
@@ -312,7 +315,8 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
             lhs.dependencies == rhs.dependencies &&
             lhs.mergedBinaryType == rhs.mergedBinaryType &&
             lhs.mergeable == rhs.mergeable &&
-            lhs.environmentVariables == rhs.environmentVariables
+            lhs.environmentVariables == rhs.environmentVariables &&
+            lhs.type == rhs.type
     }
 
     public func hash(into hasher: inout Hasher) {
@@ -322,6 +326,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
         hasher.combine(bundleId)
         hasher.combine(productName)
         hasher.combine(environmentVariables)
+        hasher.combine(type)
     }
 
     /// Returns a new copy of the target with the given InfoPlist set.

--- a/Sources/XcodeGraph/Models/TargetType.swift
+++ b/Sources/XcodeGraph/Models/TargetType.swift
@@ -1,6 +1,6 @@
 public enum TargetType: Codable, Hashable, Equatable, Sendable {
     /// A target is local when it hasn't been resolved and pulled by a package manager (e.g., SPM).
     case local
-    /// A target is remote, when it has been resolved and pulled by a package manager (e.g., SPM).
+    /// A target is remote, when it has been resolved and pulled by a package manager (e.g., SwiftPM).
     case remote
 }

--- a/Sources/XcodeGraph/Models/TargetType.swift
+++ b/Sources/XcodeGraph/Models/TargetType.swift
@@ -1,0 +1,6 @@
+public enum TargetType: Codable, Hashable, Equatable, Sendable {
+    /// A target is local when it hasn't been resolved and pulled by a package manager (e.g., SPM).
+    case local
+    /// A target is remote, when it has been resolved and pulled by a package manager (e.g., SPM).
+    case remote
+}


### PR DESCRIPTION
Replaces the `isLocal` boolean property with a new `TargetType` enum that better represents whether a target is local or remote. This change provides more explicit semantics around target types and removes the need for documentation comments explaining the boolean's meaning.