### PR TITLE
feat: add TestableTarget.parallelization property

### DIFF
--- a/Sources/XcodeGraph/Models/TestableTarget.swift
+++ b/Sources/XcodeGraph/Models/TestableTarget.swift
@@ -3,27 +3,61 @@ import Path
 
 /// Testable target describe target and tests information.
 public struct TestableTarget: Equatable, Hashable, Codable, Sendable {
+    /// With the introduction of Swift Testing and Xcode 16, you can now choose to run your tests
+    /// in parallel across either the full suite of tests in a target with `.all`, just those created
+    /// under Swift Testing with `.swiftTestingOnly`, or run them serially with the `.none` option.
+    public enum Parallelization: Equatable, Hashable, Codable, Sendable {
+        case none, swiftTestingOnly, all
+    }
+
     /// The target name and its project path.
     public let target: TargetReference
     /// Skip test target from TestAction.
     public let isSkipped: Bool
+
     /// Execute tests in parallel.
-    public let isParallelizable: Bool
+    @available(
+        *,
+        deprecated,
+        renamed: "parallelization",
+        message: "isParallelizable was deprecated. Use the paralellization property instead."
+    )
+    public var isParallelizable: Bool {
+        parallelization == .none
+    }
+
+    public let parallelization: Parallelization
+
     /// Execute tests in random order.
     public let isRandomExecutionOrdering: Bool
     /// A simulated location used when testing this test target.
     public let simulatedLocation: SimulatedLocation?
 
+    @available(*, deprecated, renamed: "init(target:skipped:parallelization:randomExecutionOrdering:simulatedLocation:)")
     public init(
         target: TargetReference,
         skipped: Bool = false,
-        parallelizable: Bool = false,
+        parallelizable: Bool,
         randomExecutionOrdering: Bool = false,
         simulatedLocation: SimulatedLocation? = nil
     ) {
         self.target = target
         isSkipped = skipped
-        isParallelizable = parallelizable
+        parallelization = parallelizable ? .all : .none
+        isRandomExecutionOrdering = randomExecutionOrdering
+        self.simulatedLocation = simulatedLocation
+    }
+
+    public init(
+        target: TargetReference,
+        skipped: Bool = false,
+        parallelization: Parallelization = .none,
+        randomExecutionOrdering: Bool = false,
+        simulatedLocation: SimulatedLocation? = nil
+    ) {
+        self.target = target
+        isSkipped = skipped
+        self.parallelization = parallelization
         isRandomExecutionOrdering = randomExecutionOrdering
         self.simulatedLocation = simulatedLocation
     }

--- a/Tests/XcodeGraphTests/Models/TestableTargetTests.swift
+++ b/Tests/XcodeGraphTests/Models/TestableTargetTests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import XcodeGraph
 
 final class TestableTargetTests: XCTestCase {
-    func test_codable() {
+    func test_codable_with_deprecated_parallelizable() {
         // Given
         let subject = TestableTarget(
             target: .init(
@@ -14,6 +14,22 @@ final class TestableTargetTests: XCTestCase {
             ),
             skipped: true,
             parallelizable: true,
+            randomExecutionOrdering: true
+        )
+
+        // Then
+        XCTAssertCodable(subject)
+    }
+
+    func test_codable() {
+        // Given
+        let subject = TestableTarget(
+            target: .init(
+                projectPath: try! AbsolutePath(validating: "/path/to/project"),
+                name: "name"
+            ),
+            skipped: true,
+            parallelization: .all,
             randomExecutionOrdering: true
         )
 


### PR DESCRIPTION
Adding `TestableTarget.parallelization` property that was added in `XcodeProj` in: https://github.com/tuist/XcodeProj/pull/871

For more context, see also the Tuist PR: https://github.com/tuist/tuist/pull/7200