### PR TITLE
fix: revert staticFramework supporting resources

### DIFF
--- a/Sources/XcodeGraph/Models/Target.swift
+++ b/Sources/XcodeGraph/Models/Target.swift
@@ -212,7 +212,6 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
         switch product {
         case .app,
              .framework,
-             .staticFramework,
              .unitTests,
              .uiTests,
              .bundle,
@@ -231,6 +230,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
              .macro,
              .dynamicLibrary,
              .staticLibrary,
+             .staticFramework,
              .xpc:
             return false
         }


### PR DESCRIPTION
See the counterpart PR at `tuist/tuist` for the reasoning: https://github.com/tuist/tuist/pull/7232