### PR TITLE
feat: add new infoPlist case `extendingFile`

### DIFF
--- a/Sources/XcodeGraph/Models/Plist.swift
+++ b/Sources/XcodeGraph/Models/Plist.swift
@@ -107,11 +107,14 @@ public enum InfoPlist: Equatable, Codable, Sendable {
     // for the target type.
     case extendingDefault(with: [String: Plist.Value])
 
+    // User defined dictionary of keys/values to extend an existing info.plist file.
+    case extendingFile(path: AbsolutePath, with: [String: Plist.Value])
+
     // MARK: - Public
 
     public var path: AbsolutePath? {
         switch self {
-        case let .file(path), let .generatedFile(path: path, data: _):
+        case let .file(path), let .generatedFile(path: path, data: _), let .extendingFile(path: path, with: _):
             return path
         default:
             return nil

--- a/Tests/XcodeGraphTests/Models/InfoPlistTests.swift
+++ b/Tests/XcodeGraphTests/Models/InfoPlistTests.swift
@@ -50,6 +50,15 @@ final class InfoPlistTests: XCTestCase {
         XCTAssertEqual(subject.path, path)
     }
 
+    func test_path_when_extendingFile() {
+        // Given
+        let path = try! AbsolutePath(validating: "/path/Info.list")
+        let subject: InfoPlist = .extendingFile(path: path, with: [:])
+        
+        // Then
+        XCTAssertEqual(subject.path, path)
+    }
+
     func test_expressive_by_string_literal() {
         // Given
         let subject: InfoPlist = "/path/Info.list"

--- a/Tests/XcodeGraphTests/Models/InfoPlistTests.swift
+++ b/Tests/XcodeGraphTests/Models/InfoPlistTests.swift
@@ -25,6 +25,22 @@ final class InfoPlistTests: XCTestCase {
         XCTAssertCodable(subject)
     }
 
+    func test_codable_extendingFile() {
+        // Given
+        let path = try! AbsolutePath(validating: "/path/Info.list")
+        let subject = InfoPlist.extendingFile(
+            path: path,
+            with: [
+                "key1": "value1",
+                "key2": "value2",
+                "key3": "value3",
+            ]
+        )
+
+        // Then
+        XCTAssertCodable(subject)
+    }
+
     func test_path_when_file() {
         // Given
         let path = try! AbsolutePath(validating: "/path/Info.list")


### PR DESCRIPTION
Adding `.extendingFile(path: AbsolutePath, with: [String: Plist.Value])` case to `InfoPlist` enum.

This allows extending an existing Info.plist file by adding new key-value pairs or overriding existing ones.

Relates to:
- https://github.com/tuist/tuist/pull/7286