### PR TITLE
fix: make Graph test factory public

### DIFF
--- a/Sources/XcodeGraph/Graph/Graph.swift
+++ b/Sources/XcodeGraph/Graph/Graph.swift
@@ -68,7 +68,7 @@ extension [GraphEdge: PlatformCondition] {
 
 #if DEBUG
     extension Graph {
-        static func test(
+        public static func test(
             name: String = "graph",
             path: AbsolutePath = .root,
             workspace: Workspace = .test(),


### PR DESCRIPTION
This method was made accidentally internal in https://github.com/tuist/XcodeGraph/pull/87 and it breaks testing code in `tuist/tuist` on update of `XcodeGraph`. cc @ajkolean 