### PR TITLE
fix: remove .xcodeproj path component from most paths

### DIFF
--- a/Sources/XcodeGraphMapper/Mappers/Graph/XcodeGraphMapper.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Graph/XcodeGraphMapper.swift
@@ -173,7 +173,7 @@ public struct XcodeGraphMapper: XcodeGraphMapping {
             let xcodeProj = try XcodeProj(pathString: path.pathString)
             let projectMapper = PBXProjectMapper()
             let project = try await projectMapper.map(xcodeProj: xcodeProj)
-            projects[path] = project
+            projects[path.parentDirectory] = project
         }
 
         return projects
@@ -209,7 +209,7 @@ public struct XcodeGraphMapper: XcodeGraphMapping {
 
         for (path, project) in projects {
             for (name, target) in project.targets {
-                let sourceDependency = GraphDependency.target(name: name, path: path.parentDirectory)
+                let sourceDependency = GraphDependency.target(name: name, path: path)
 
                 // Build edges for each target dependency
                 let edgesAndDeps = try await target.dependencies.serialCompactMap { (dep: TargetDependency) async throws -> (
@@ -218,7 +218,7 @@ public struct XcodeGraphMapper: XcodeGraphMapping {
                     GraphDependency
                 ) in
                     let graphDep = try await dep.graphDependency(
-                        sourceDirectory: path.parentDirectory,
+                        sourceDirectory: path,
                         allTargetsMap: allTargetsMap,
                         target: target
                     )

--- a/Sources/XcodeGraphMapper/Mappers/Schemes/XCSchemeMapper.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Schemes/XCSchemeMapper.swift
@@ -200,7 +200,7 @@ struct XCSchemeMapper: SchemeMapping {
             let relPath = try RelativePath(validating: relativeContainerPath)
             projectPath = xcworkspace.workspacePath.parentDirectory.appending(relPath)
         case let .project(xcodeProj):
-            projectPath = xcodeProj.projectPath
+            projectPath = xcodeProj.projectPath.parentDirectory
         }
 
         return TargetReference(projectPath: projectPath, name: targetName)

--- a/Tests/XcodeGraphMapperTests/MapperTests/Graph/GraphMapperTests.swift
+++ b/Tests/XcodeGraphMapperTests/MapperTests/Graph/GraphMapperTests.swift
@@ -130,15 +130,15 @@ struct XcodeGraphMapperTests {
 
         // When
         let graph = try await mapper.buildGraph(from: .workspace(xcworkspace))
-        print(projectA.path!)
+
         // Then
         #expect(graph.workspace.name == "Workspace")
         #expect(graph.workspace.projects.contains(projectA.projectPath) == true)
         #expect(graph.workspace.projects.contains(projectB.projectPath) == true)
         #expect(graph.projects.count == 2)
 
-        let mappedProjectA = try #require(graph.projects[projectA.projectPath])
-        let mappedProjectB = try #require(graph.projects[projectB.projectPath])
+        let mappedProjectA = try #require(graph.projects[projectA.projectPath.parentDirectory])
+        let mappedProjectB = try #require(graph.projects[projectB.projectPath.parentDirectory])
         #expect(mappedProjectA.targets["ATarget"] != nil)
         #expect(mappedProjectB.targets["BTarget"] != nil)
 

--- a/Tests/XcodeGraphMapperTests/MapperTests/Schemes/XCSchemeMapperTests.swift
+++ b/Tests/XcodeGraphMapperTests/MapperTests/Schemes/XCSchemeMapperTests.swift
@@ -256,7 +256,7 @@ struct XCSchemeMapperTests {
         // Then
         #expect(mappedAction.targets.count == 1)
         #expect(mappedAction.targets[0].name == "App")
-        #expect(mappedAction.targets[0].projectPath == xcodeProj.projectPath)
+        #expect(mappedAction.targets[0].projectPath == xcodeProj.projectPath.parentDirectory)
     }
 
     @Test("Handles schemes without any actions gracefully")


### PR DESCRIPTION
Dependency and project paths currently include the `.xcodeproj` component, such as `some-path/project/Project.xcodeproj`. However, in `tuist/tuist`, project paths usually reference to `some-path/project` without the `Project.xcodeproj`. This PR aligns the mapper with this convention.

When the path to `.xcodeproj` is needed, we can still use the `xcodeProjPath` of `Project`.

cc @ajkolean 