### PR TITLE
fix: missing framework target dependency

### DIFF
--- a/Sources/XcodeGraphMapper/Mappers/Phases/PBXFrameworksBuildPhaseMapper.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Phases/PBXFrameworksBuildPhaseMapper.swift
@@ -42,6 +42,18 @@ struct PBXFrameworksBuildPhaseMapper: PBXFrameworksBuildPhaseMapping {
         xcodeProj: XcodeProj
     ) throws -> TargetDependency {
         let fileRef = try buildFile.file.throwing(PBXFrameworksBuildPhaseMappingError.missingFileReference)
+        switch fileRef.sourceTree {
+        case .buildProductsDir:
+            guard let path = fileRef.path else { break }
+            let name = path.replacingOccurrences(of: ".framework", with: "")
+            return .target(
+                name: name,
+                status: .required,
+                condition: nil
+            )
+        default:
+            break
+        }
         let filePathString = try fileRef.fullPath(sourceRoot: xcodeProj.srcPathString)
             .throwing(PBXFrameworksBuildPhaseMappingError.missingFilePath(name: fileRef.name))
 


### PR DESCRIPTION
When mapping framework dependencies, we were assuming that a framework would be referred by a full path. However, that's not the case when a target depends on a different framework target. In those cases, frameworks are referred to by their relative path and their `sourceTree` is `buildProductsDir`.