### PR TITLE
fix: improve performance of XcodeGraphMapper

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "03c49df71ea05c212cda45628b910ec850be3d5268ad44afcf323333a40b1224",
+  "originHash" : "d85d2800ade4b7815fc45dc86a042a0565bf66be2c0a52d40c24b35d11f9a0be",
   "pins" : [
     {
       "identity" : "aexml",
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj",
       "state" : {
-        "revision" : "647cba2719e85748ec82d0720ee7afe5b7a6421e",
-        "version" : "8.26.3"
+        "revision" : "6f90427e172da66336739801c84b9cef3e17367b",
+        "version" : "8.26.6"
       }
     },
     {

--- a/Sources/XcodeGraphMapper/Mappers/Project/PBXProjectMapper.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Project/PBXProjectMapper.swift
@@ -45,20 +45,20 @@ struct PBXProjectMapper: PBXProjectMapping {
 
         // Map PBXTargets to domain Targets
         let targetMapper = PBXTargetMapper()
-let targets = try await withThrowingTaskGroup(of: Target.self, returning: [Target].self) { taskGroup in
-    for pbxTarget in pbxProject.targets {
-        taskGroup.addTask {
-            try await targetMapper.map(pbxTarget: pbxTarget, xcodeProj: xcodeProj)
-        }
-    }
+        let targets = try await withThrowingTaskGroup(of: Target.self, returning: [Target].self) { taskGroup in
+            for pbxTarget in pbxProject.targets {
+                taskGroup.addTask {
+                    try await targetMapper.map(pbxTarget: pbxTarget, xcodeProj: xcodeProj)
+                }
+            }
 
-    var targets: [Target] = []
-    for try await target in taskGroup {
-        targets.append(target)
-    }
-    
-    return targets
-}
+            var targets: [Target] = []
+            for try await target in taskGroup {
+                targets.append(target)
+            }
+
+            return targets
+        }
         .sorted()
 
         // Map remote and local packages

--- a/Sources/XcodeGraphMapper/Mappers/Project/PBXProjectMapper.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Project/PBXProjectMapper.swift
@@ -45,8 +45,15 @@ struct PBXProjectMapper: PBXProjectMapping {
 
         // Map PBXTargets to domain Targets
         let targetMapper = PBXTargetMapper()
-        let targets = try await pbxProject.targets.serialCompactMap {
-            try await targetMapper.map(pbxTarget: $0, xcodeProj: xcodeProj)
+        let targets = try await withThrowingTaskGroup(of: Void.self, returning: [Target].self) { taskGroup in
+            var targets: [Target] = []
+            for pbxTarget in pbxProject.targets {
+                taskGroup.addTask {
+                    targets.append(try await targetMapper.map(pbxTarget: pbxTarget, xcodeProj: xcodeProj))
+                }
+            }
+            try await taskGroup.waitForAll()
+            return targets
         }
         .sorted()
 


### PR DESCRIPTION
When I ran `XcodeGraphMapper` on `tuist/tuist`, it was _very_ slow. Mapping projects concurrently improves things a ton and thanks to the functional mapper approach, doing this is a couple of line. We can consider running more granular mappers if the performance would be still an issue for large projects.