### PR TITLE
fix: do not map project target dependency to an underlying type

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d85d2800ade4b7815fc45dc86a042a0565bf66be2c0a52d40c24b35d11f9a0be",
+  "originHash" : "252c1ee702d5bd9c4155485fe13cdca178e46fc497b3f48683ff138bb43d7492",
   "pins" : [
     {
       "identity" : "aexml",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/Command.git",
       "state" : {
-        "revision" : "437e0c0ca18d1a16194c55b4690971b5bfb1f185",
-        "version" : "0.12.0"
+        "revision" : "9d03a95faa94b961edc1cf2c5f4379b0108ee97a",
+        "version" : "0.12.1"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-service-context",
       "state" : {
-        "revision" : "0c62c5b4601d6c125050b5c3a97f20cce881d32b",
-        "version" : "1.1.0"
+        "revision" : "8946c930cae601452149e45d31d8ddfac973c3c7",
+        "version" : "1.2.0"
       }
     },
     {

--- a/Sources/XcodeGraphMapper/Mappers/Graph/XcodeGraphMapper.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Graph/XcodeGraphMapper.swift
@@ -193,16 +193,11 @@ public struct XcodeGraphMapper: XcodeGraphMapping {
     private func resolveDependencies(
         for projects: [AbsolutePath: Project]
     ) async throws -> ([GraphDependency: Set<GraphDependency>], [GraphEdge: PlatformCondition]) {
-        let allTargetsMap = Dictionary(
-            projects.values.flatMap(\.targets),
-            uniquingKeysWith: { existing, _ in existing }
-        )
-        return try await buildDependencies(for: projects, using: allTargetsMap)
+        return try await buildDependencies(for: projects)
     }
 
     private func buildDependencies(
-        for projects: [AbsolutePath: Project],
-        using allTargetsMap: [String: Target]
+        for projects: [AbsolutePath: Project]
     ) async throws -> ([GraphDependency: Set<GraphDependency>], [GraphEdge: PlatformCondition]) {
         var dependencies = [GraphDependency: Set<GraphDependency>]()
         var dependencyConditions = [GraphEdge: PlatformCondition]()
@@ -219,7 +214,6 @@ public struct XcodeGraphMapper: XcodeGraphMapping {
                 ) in
                     let graphDep = try await dep.graphDependency(
                         sourceDirectory: path,
-                        allTargetsMap: allTargetsMap,
                         target: target
                     )
                     return (GraphEdge(from: sourceDependency, to: graphDep), dep.condition, graphDep)


### PR DESCRIPTION
I am not 100 % sure why we were mapping project target dependencies to cases such as `.framework`, however, this breaks some of the logic in `tuist`. Dependency to cases like `.framework` are only when those products are _prebuilt_. That's not the case for project target dependencies.

Additionally, this simplifies the mapping logic a bit.