### PR TITLE
fix: correctly map project target framework

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d85d2800ade4b7815fc45dc86a042a0565bf66be2c0a52d40c24b35d11f9a0be",
+  "originHash" : "252c1ee702d5bd9c4155485fe13cdca178e46fc497b3f48683ff138bb43d7492",
   "pins" : [
     {
       "identity" : "aexml",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/Command.git",
       "state" : {
-        "revision" : "437e0c0ca18d1a16194c55b4690971b5bfb1f185",
-        "version" : "0.12.0"
+        "revision" : "9d03a95faa94b961edc1cf2c5f4379b0108ee97a",
+        "version" : "0.12.1"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-service-context",
       "state" : {
-        "revision" : "0c62c5b4601d6c125050b5c3a97f20cce881d32b",
-        "version" : "1.1.0"
+        "revision" : "8946c930cae601452149e45d31d8ddfac973c3c7",
+        "version" : "1.2.0"
       }
     },
     {

--- a/Sources/XcodeGraphMapper/Mappers/Phases/PBXFrameworksBuildPhaseMapper.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Phases/PBXFrameworksBuildPhaseMapper.swift
@@ -50,6 +50,13 @@ struct PBXFrameworksBuildPhaseMapper: PBXFrameworksBuildPhaseMapping {
         xcodeProj: XcodeProj,
         projectNativeTargets: [String: ProjectNativeTarget]
     ) throws -> TargetDependency {
+        if let product = buildFile.product {
+            return .package(
+                product: product.productName,
+                type: .runtime,
+                condition: nil
+            )
+        }
         let fileRef = try buildFile.file.throwing(PBXFrameworksBuildPhaseMappingError.missingFileReference)
         switch fileRef.sourceTree {
         case .buildProductsDir:
@@ -74,7 +81,7 @@ struct PBXFrameworksBuildPhaseMapper: PBXFrameworksBuildPhaseMapping {
         default:
             break
         }
-        let filePathString = try! fileRef.fullPath(sourceRoot: xcodeProj.srcPathString)
+        let filePathString = try fileRef.fullPath(sourceRoot: xcodeProj.srcPathString)
             .throwing(PBXFrameworksBuildPhaseMappingError.missingFilePath(name: fileRef.name))
 
         let absolutePath = try AbsolutePath(validating: filePathString)

--- a/Sources/XcodeGraphMapper/Mappers/Project/PBXProjectMapper.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Project/PBXProjectMapper.swift
@@ -14,7 +14,10 @@ protocol PBXProjectMapping {
     /// - Parameter xcodeProj: The Xcode project to be transformed.
     /// - Returns: A fully constructed `Project` model.
     /// - Throws: If reading or transforming project data fails.
-    func map(xcodeProj: XcodeProj) async throws -> Project
+    func map(
+        xcodeProj: XcodeProj,
+        projectNativeTargets: [String: ProjectNativeTarget]
+    ) async throws -> Project
 }
 
 /// A mapper that transforms a `.xcodeproj` into a `Project` domain model.
@@ -31,7 +34,10 @@ struct PBXProjectMapper: PBXProjectMapping {
     /// - Parameter xcodeProj: The Xcode project reference containing `.pbxproj` data.
     /// - Returns: A fully constructed `Project` model.
     /// - Throws: If reading or transforming project data fails.
-    func map(xcodeProj: XcodeProj) async throws -> Project {
+    func map(
+        xcodeProj: XcodeProj,
+        projectNativeTargets: [String: ProjectNativeTarget]
+    ) async throws -> Project {
         let settingsMapper = XCConfigurationMapper()
         let pbxProject = try xcodeProj.mainPBXProject()
         let xcodeProjPath = xcodeProj.projectPath
@@ -48,7 +54,11 @@ struct PBXProjectMapper: PBXProjectMapping {
         let targets = try await withThrowingTaskGroup(of: Target.self, returning: [Target].self) { taskGroup in
             for pbxTarget in pbxProject.targets {
                 taskGroup.addTask {
-                    try await targetMapper.map(pbxTarget: pbxTarget, xcodeProj: xcodeProj)
+                    try await targetMapper.map(
+                        pbxTarget: pbxTarget,
+                        xcodeProj: xcodeProj,
+                        projectNativeTargets: projectNativeTargets
+                    )
                 }
             }
 

--- a/Sources/XcodeGraphMapper/Utilities/ProjectNativeTarget.swift
+++ b/Sources/XcodeGraphMapper/Utilities/ProjectNativeTarget.swift
@@ -1,0 +1,7 @@
+import XcodeProj
+
+/// Model representing a `PBXNativeTarget` in a give `XcodeProj`
+struct ProjectNativeTarget {
+    let nativeTarget: PBXNativeTarget
+    let project: XcodeProj
+}

--- a/Tests/XcodeGraphMapperTests/MapperTests/Phases/PBXFrameworksBuildPhaseMapperTests.swift
+++ b/Tests/XcodeGraphMapperTests/MapperTests/Phases/PBXFrameworksBuildPhaseMapperTests.swift
@@ -47,12 +47,18 @@ struct PBXFrameworksBuildPhaseMapperTests {
             settings: ["ATTRIBUTES": ["Weak"]]
         ).add(to: pbxProj)
 
+        let packageProduct = XCSwiftPackageProductDependency(productName: "PackageProduct")
+        let packageProductBuildFile = PBXBuildFile(
+            product: packageProduct
+        ).add(to: pbxProj)
+
         let frameworksPhase = PBXFrameworksBuildPhase(
             files: [
                 frameworkBuildFile,
                 targetFrameworkBuildFile,
                 projectTargetFrameworkBuildFile,
                 weakProjectTargetFrameworkBuildFile,
+                packageProductBuildFile,
             ]
         ).add(to: pbxProj)
 
@@ -104,6 +110,11 @@ struct PBXFrameworksBuildPhaseMapperTests {
                 .framework(
                     path: frameworkPath,
                     status: .required,
+                    condition: nil
+                ),
+                .package(
+                    product: "PackageProduct",
+                    type: .runtime,
                     condition: nil
                 ),
                 .project(

--- a/Tests/XcodeGraphMapperTests/MapperTests/Project/PBXProjectMapperTests.swift
+++ b/Tests/XcodeGraphMapperTests/MapperTests/Project/PBXProjectMapperTests.swift
@@ -13,7 +13,7 @@ struct PBXProjectMapperTests {
         let mapper = PBXProjectMapper()
 
         // When
-        let project = try await mapper.map(xcodeProj: xcodeProj)
+        let project = try await mapper.map(xcodeProj: xcodeProj, projectNativeTargets: [:])
 
         // Then
         #expect(project.name == "TestProject")
@@ -38,7 +38,7 @@ struct PBXProjectMapperTests {
         xcodeProj.pbxproj.projects.first?.attributes = customAttributes
 
         // When
-        let project = try await mapper.map(xcodeProj: xcodeProj)
+        let project = try await mapper.map(xcodeProj: xcodeProj, projectNativeTargets: [:])
 
         // Then
         #expect(project.name == "TestProject")
@@ -62,7 +62,7 @@ struct PBXProjectMapperTests {
         let mapper = PBXProjectMapper()
 
         // When
-        let project = try await mapper.map(xcodeProj: xcodeProj)
+        let project = try await mapper.map(xcodeProj: xcodeProj, projectNativeTargets: [:])
 
         // Then
         #expect(project.packages.count == 1)
@@ -82,7 +82,7 @@ struct PBXProjectMapperTests {
         let mapper = PBXProjectMapper()
 
         // When
-        let project = try await mapper.map(xcodeProj: xcodeProj)
+        let project = try await mapper.map(xcodeProj: xcodeProj, projectNativeTargets: [:])
 
         // Then
         #expect(project.defaultKnownRegions?.count == 3)
@@ -99,7 +99,7 @@ struct PBXProjectMapperTests {
         let mapper = PBXProjectMapper()
 
         // When
-        let project = try await mapper.map(xcodeProj: xcodeProj)
+        let project = try await mapper.map(xcodeProj: xcodeProj, projectNativeTargets: [:])
 
         // Then
         #expect(project.developmentRegion == "fr")
@@ -112,7 +112,7 @@ struct PBXProjectMapperTests {
         let mapper = PBXProjectMapper()
 
         // When
-        let project = try await mapper.map(xcodeProj: xcodeProj)
+        let project = try await mapper.map(xcodeProj: xcodeProj, projectNativeTargets: [:])
         let synthesizers = project.resourceSynthesizers
 
         // Then
@@ -145,7 +145,7 @@ struct PBXProjectMapperTests {
         let mapper = PBXProjectMapper()
 
         // When
-        let project = try await mapper.map(xcodeProj: xcodeProj)
+        let project = try await mapper.map(xcodeProj: xcodeProj, projectNativeTargets: [:])
 
         // Then
         #expect(project.schemes.count == 1)

--- a/Tests/XcodeGraphMapperTests/MapperTests/Target/PBXTargetMapperTests.swift
+++ b/Tests/XcodeGraphMapperTests/MapperTests/Target/PBXTargetMapperTests.swift
@@ -26,7 +26,7 @@ struct PBXTargetMapperTests: Sendable {
         // When
         let mapper = PBXTargetMapper()
 
-        let mapped = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj)
+        let mapped = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj, projectNativeTargets: [:])
 
         // Then
         #expect(mapped.name == "App")
@@ -50,7 +50,7 @@ struct PBXTargetMapperTests: Sendable {
 
         // When / Then
         await #expect(throws: PBXTargetMappingError.missingBundleIdentifier(targetName: "App")) {
-            _ = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj)
+            _ = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj, projectNativeTargets: [:])
         }
     }
 
@@ -70,7 +70,7 @@ struct PBXTargetMapperTests: Sendable {
         let mapper = PBXTargetMapper()
 
         // When
-        let mapped = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj)
+        let mapped = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj, projectNativeTargets: [:])
 
         // Then
         #expect(mapped.environmentVariables["TEST_VAR"]?.value == "test_value")
@@ -94,7 +94,7 @@ struct PBXTargetMapperTests: Sendable {
         let mapper = PBXTargetMapper()
 
         // When
-        let mapped = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj)
+        let mapped = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj, projectNativeTargets: [:])
 
         // Then
         let expected = [
@@ -130,7 +130,7 @@ struct PBXTargetMapperTests: Sendable {
         let mapper = PBXTargetMapper()
 
         // When
-        let mapped = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj)
+        let mapped = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj, projectNativeTargets: [:])
 
         // Then
         #expect(mapped.sources.count == 1)
@@ -212,7 +212,7 @@ struct PBXTargetMapperTests: Sendable {
             )
 
             // When
-            let mapped = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj)
+            let mapped = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj, projectNativeTargets: [:])
 
             // Then
             #expect(
@@ -285,7 +285,7 @@ struct PBXTargetMapperTests: Sendable {
         let mapper = PBXTargetMapper()
 
         // When
-        let mapped = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj)
+        let mapped = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj, projectNativeTargets: [:])
 
         // Then
         #expect(mapped.metadata.tags == Set(["tag1", "tag2", "tag3"]))
@@ -338,7 +338,7 @@ struct PBXTargetMapperTests: Sendable {
         let mapper = PBXTargetMapper()
 
         // When
-        let mapped = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj)
+        let mapped = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj, projectNativeTargets: [:])
 
         // Then
         #expect(mapped.entitlements == .file(
@@ -361,7 +361,7 @@ struct PBXTargetMapperTests: Sendable {
         // When / Then
 
         do {
-            _ = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj)
+            _ = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj, projectNativeTargets: [:])
             Issue.record("Should throw an error")
         } catch {
             let err = try #require(error as? PBXObjectError)
@@ -400,7 +400,7 @@ struct PBXTargetMapperTests: Sendable {
         let mapper = PBXTargetMapper()
 
         // When
-        let mapped = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj)
+        let mapped = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj, projectNativeTargets: [:])
 
         // Then
         #expect({
@@ -439,7 +439,7 @@ struct PBXTargetMapperTests: Sendable {
 
         // When / Then
         await #expect {
-            _ = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj)
+            _ = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj, projectNativeTargets: [:])
         } throws: { error in
             error.localizedDescription
                 == "Failed to read a valid plist dictionary from file at: \(invalidPlistPath.pathString)."


### PR DESCRIPTION
When mapping a target framework from a different project, we would incorrectly default to a `.target` framework dependency. To fix this, we are constructing a map of target names to a `ProjectNativeTarget` – a helper struct that contains the necessary models we need to return a `TargetDependency.project`.

Additionally, we are now reading `buildSettings` of a given target framework to derive the `linkingStatus`.