### PR TITLE
fix: map test plans

### DIFF
--- a/Sources/XcodeGraphMapper/Mappers/Project/PBXProjectMapper.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Project/PBXProjectMapper.swift
@@ -86,12 +86,18 @@ struct PBXProjectMapper: PBXProjectMapping {
         // Map user and shared schemes
         let schemeMapper = XCSchemeMapper()
         let graphType: XcodeMapperGraphType = .project(xcodeProj)
-        let userSchemes = try xcodeProj.userData.flatMap(\.schemes).map {
-            try schemeMapper.map($0, shared: false, graphType: graphType)
+        var userSchemes: [Scheme] = []
+        for scheme in try xcodeProj.userData.flatMap(\.schemes) {
+            userSchemes.append(
+                try await schemeMapper.map(scheme, shared: false, graphType: graphType)
+            )
         }
-        let sharedSchemes = try xcodeProj.sharedData?.schemes.map {
-            try schemeMapper.map($0, shared: true, graphType: graphType)
-        } ?? []
+        var sharedSchemes: [Scheme] = []
+        for scheme in try (xcodeProj.sharedData?.schemes ?? []) {
+            sharedSchemes.append(
+                try await schemeMapper.map(scheme, shared: true, graphType: graphType)
+            )
+        }
         let schemes = userSchemes + sharedSchemes
 
         // Other project-level metadata

--- a/Sources/XcodeGraphMapper/Mappers/Schemes/XCTestPlan.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Schemes/XCTestPlan.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+struct XCTestPlan: Codable {
+    struct TestTarget: Codable {
+        let parallelizable: Bool?
+        let target: TestTargetReference
+    }
+
+    struct TestTargetReference: Codable {
+        let containerPath: String
+        let identifier: String
+        let name: String
+    }
+
+    let testTargets: [TestTarget]
+}

--- a/Tests/XcodeGraphMapperTests/MapperTests/Target/PBXTargetMapperTests.swift
+++ b/Tests/XcodeGraphMapperTests/MapperTests/Target/PBXTargetMapperTests.swift
@@ -446,7 +446,7 @@ struct PBXTargetMapperTests: Sendable {
         let mapper = PBXTargetMapper()
 
         // When
-        let mapped = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj)
+        let mapped = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj, projectNativeTargets: [:])
 
         // Then
         #expect(
@@ -491,7 +491,7 @@ struct PBXTargetMapperTests: Sendable {
         let mapper = PBXTargetMapper()
 
         // When
-        let mapped = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj)
+        let mapped = try await mapper.map(pbxTarget: target, xcodeProj: xcodeProj, projectNativeTargets: [:])
 
         // Then
         #expect(


### PR DESCRIPTION
When mapping `XCScheme`, we would not try to map test plans at all. This PR fixes this omission.