### PR TITLE
fix: encoding of XCFrameworkInfoPlist

### DIFF
--- a/Sources/XcodeGraph/Models/XCFrameworkInfoPlist.swift
+++ b/Sources/XcodeGraph/Models/XCFrameworkInfoPlist.swift
@@ -50,6 +50,7 @@ public struct XCFrameworkInfoPlist: Codable, Hashable, Equatable, Sendable {
             try container.encode(path, forKey: .path)
             try container.encode(mergeable, forKey: .mergeable)
             try container.encode(architectures, forKey: .architectures)
+            try container.encode(platform, forKey: .platform)
         }
 
         public init(

--- a/Tests/XcodeGraphTests/Models/XCFrameworkInfoPlistTests.swift
+++ b/Tests/XcodeGraphTests/Models/XCFrameworkInfoPlistTests.swift
@@ -1,0 +1,14 @@
+import Foundation
+import Path
+import XCTest
+@testable import XcodeGraph
+
+final class XCFrameworkInfoPlistTests: XCTestCase {
+    func test_codable() throws {
+        // Given
+        let subject: XCFrameworkInfoPlist = .test()
+
+        // Then
+        XCTAssertCodable(subject)
+    }
+}


### PR DESCRIPTION
## 📝 Description

This PR fixes the encoding of `XCFrameworkInfoPlist`. 

When encoding the `XcodeGraph.Graph` type it appears to miss the `platform` property. This leads to decoding Issues when decoding the data again. 