### PR TITLE
fix: mapping build phases with exceptions

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "252c1ee702d5bd9c4155485fe13cdca178e46fc497b3f48683ff138bb43d7492",
+  "originHash" : "a0c582ac4ca6203193d903182729cbfc3421a26c187eda13dbf15825aa4658e7",
   "pins" : [
     {
       "identity" : "aexml",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/Command.git",
       "state" : {
-        "revision" : "9d03a95faa94b961edc1cf2c5f4379b0108ee97a",
-        "version" : "0.12.1"
+        "revision" : "07846291097a593de29846c0083b758471071cdf",
+        "version" : "0.12.2"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/FileSystem.git",
       "state" : {
-        "revision" : "267329f17e523575162f0887d20f2b78f609585a",
-        "version" : "0.7.6"
+        "revision" : "1bff6d54e90a79706a4a9d77cd081104de430361",
+        "version" : "0.7.7"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio",
       "state" : {
-        "revision" : "dff45738d84a53dbc8ee899c306b3a7227f54f89",
-        "version" : "2.80.0"
+        "revision" : "c51907a839e63ebf0ba2076bba73dd96436bd1b9",
+        "version" : "2.81.0"
       }
     },
     {
@@ -166,10 +166,10 @@
     {
       "identity" : "xcodeproj",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tuist/XcodeProj",
+      "location" : "https://github.com/adincebic/XcodeProj",
       "state" : {
-        "revision" : "6f90427e172da66336739801c84b9cef3e17367b",
-        "version" : "8.26.6"
+        "branch" : "support/PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet",
+        "revision" : "aa1a3c98a2d1a3fdd7e7464e7849c6c7a1b7c2aa"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a0c582ac4ca6203193d903182729cbfc3421a26c187eda13dbf15825aa4658e7",
+  "originHash" : "377d0890e78ed330d863806cbf4cdc28ce4dc14faeb68c692140ca84153f49ff",
   "pins" : [
     {
       "identity" : "aexml",
@@ -166,10 +166,10 @@
     {
       "identity" : "xcodeproj",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/adincebic/XcodeProj",
+      "location" : "https://github.com/tuist/XcodeProj",
       "state" : {
-        "branch" : "support/PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet",
-        "revision" : "aa1a3c98a2d1a3fdd7e7464e7849c6c7a1b7c2aa"
+        "revision" : "b9992de5b44b37a25c57e472a17e392f20923d71",
+        "version" : "8.26.8"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj",
       "state" : {
-        "revision" : "b9992de5b44b37a25c57e472a17e392f20923d71",
-        "version" : "8.26.8"
+        "revision" : "142b7ea0a087eabf4d12207302a185a0e9d4659b",
+        "version" : "8.27.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -80,7 +80,10 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.6.7")),
         .package(url: "https://github.com/tuist/Path.git", .upToNextMajor(from: "0.3.8")),
-        .package(url: "https://github.com/tuist/XcodeProj", from: "8.26.7"),
+        .package(
+            url: "https://github.com/adincebic/XcodeProj",
+            branch: "support/PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet"
+        ),
         .package(url: "https://github.com/tuist/Command.git", from: "0.12.2"),
         .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.7.7")),
         .package(url: "https://github.com/apple/swift-service-context", .upToNextMajor(from: "1.2.0")),

--- a/Package.swift
+++ b/Package.swift
@@ -80,7 +80,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.6.7")),
         .package(url: "https://github.com/tuist/Path.git", .upToNextMajor(from: "0.3.8")),
-        .package(url: "https://github.com/tuist/XcodeProj", from: "8.26.7"),
+        .package(url: "https://github.com/tuist/XcodeProj", .upToNextMajor(from: "8.27.0")),
         .package(url: "https://github.com/tuist/Command.git", from: "0.12.2"),
         .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.7.7")),
         .package(url: "https://github.com/apple/swift-service-context", .upToNextMajor(from: "1.2.0")),

--- a/Package.swift
+++ b/Package.swift
@@ -80,10 +80,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.6.7")),
         .package(url: "https://github.com/tuist/Path.git", .upToNextMajor(from: "0.3.8")),
-        .package(
-            url: "https://github.com/adincebic/XcodeProj",
-            branch: "support/PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet"
-        ),
+        .package(url: "https://github.com/tuist/XcodeProj", from: "8.26.7"),
         .package(url: "https://github.com/tuist/Command.git", from: "0.12.2"),
         .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.7.7")),
         .package(url: "https://github.com/apple/swift-service-context", .upToNextMajor(from: "1.2.0")),

--- a/Sources/XcodeGraphMapper/Mappers/Phases/PBXCopyFilesBuildPhaseMapper.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Phases/PBXCopyFilesBuildPhaseMapper.swift
@@ -93,7 +93,7 @@ struct PBXCopyFilesBuildPhaseMapper: PBXCopyFilesBuildPhaseMapping {
                 let groupFiles = buildPhaseExceptions.compactMap {
                     $0.membershipExceptions?.map {
                         return CopyFileElement.file(
-                            path: xcodeProj.srcPath.appending(component: path).appending(component: $0),
+                            path: xcodeProj.srcPath.appending(component: path).appending(RelativePath($0)),
                             condition: nil,
                             codeSignOnCopy: true
                         )

--- a/Sources/XcodeGraphMapper/Mappers/Project/PBXProjectMapper.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Project/PBXProjectMapper.swift
@@ -175,7 +175,7 @@ struct PBXProjectMapper: PBXProjectMapping {
                let pathString = try file.fullPath(sourceRoot: xcodeProj.srcPathString)
             {
                 let path = try AbsolutePath(validating: pathString)
-                if try await fileSystem.exists(path, isDirectory: true),
+                if (try? await fileSystem.exists(path, isDirectory: true)) ?? false,
                    try await fileSystem.exists(path.appending(component: "Package.swift"))
                 {
                     packages.insert(path)

--- a/Sources/XcodeGraphMapper/Mappers/Targets/PBXTarget+GraphMapping.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Targets/PBXTarget+GraphMapping.swift
@@ -8,8 +8,9 @@ extension PBXTarget {
     func bundleIdentifier() throws -> String {
         if let bundleId = debugBuildSettings.string(for: .productBundleIdentifier) {
             return bundleId
+        } else {
+            return "Unknown"
         }
-        throw PBXTargetMappingError.missingBundleIdentifier(targetName: name)
     }
 
     /// Returns an array of all `PBXCopyFilesBuildPhase` instances for this target.

--- a/Sources/XcodeGraphMapper/Mappers/Targets/PBXTargetMapper.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Targets/PBXTargetMapper.swift
@@ -10,7 +10,6 @@ enum PBXTargetMappingError: LocalizedError, Equatable {
     case noProjectsFound(path: String)
     case missingFilesGroup(targetName: String)
     case invalidPlist(path: String)
-    case missingBundleIdentifier(targetName: String)
 
     var errorDescription: String? {
         switch self {
@@ -20,8 +19,6 @@ enum PBXTargetMappingError: LocalizedError, Equatable {
             return "The files group is missing for the target '\(targetName)'."
         case let .invalidPlist(path):
             return "Failed to read a valid plist dictionary from file at: \(path)."
-        case let .missingBundleIdentifier(targetName):
-            return "The bundle identifier is missing for the target '\(targetName)'."
         }
     }
 }

--- a/Sources/XcodeGraphMapper/Mappers/Targets/PBXTargetMapper.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Targets/PBXTargetMapper.swift
@@ -150,7 +150,11 @@ struct PBXTargetMapper: PBXTargetMapping {
         let rawScriptBuildPhases = scriptsMapper.mapRawScriptBuildPhases(runScriptPhases)
 
         let copyFilesPhases = pbxTarget.copyFilesBuildPhases()
-        let copyFiles = try copyFilesMapper.map(copyFilesPhases, xcodeProj: xcodeProj)
+        let copyFiles = try copyFilesMapper.map(
+            copyFilesPhases,
+            fileSystemSynchronizedGroups: pbxTarget.fileSystemSynchronizedGroups ?? [],
+            xcodeProj: xcodeProj
+        )
 
         // Core Data models
         let resourceFiles = try pbxTarget.resourcesBuildPhase()?.files ?? []
@@ -390,8 +394,9 @@ struct PBXTargetMapper: PBXTargetMapping {
         for fileSystemSynchronizedGroup in fileSystemSynchronizedGroups {
             if let path = fileSystemSynchronizedGroup.path {
                 let membershipExceptions = membershipExceptions(for: fileSystemSynchronizedGroup)
-                let additionalCompilerFlagsByRelativePath = fileSystemSynchronizedGroup.exceptions?
+                let additionalCompilerFlagsByRelativePath: [String: String]? = fileSystemSynchronizedGroup.exceptions?
                     .reduce(into: [:]) { acc, element in
+                        guard let element = element as? PBXFileSystemSynchronizedBuildFileExceptionSet else { return }
                         acc.merge(element.additionalCompilerFlagsByRelativePath ?? [:], uniquingKeysWith: { $1 })
                     }
                 let directory = xcodeProj.srcPath.appending(component: path)
@@ -429,10 +434,7 @@ struct PBXTargetMapper: PBXTargetMapping {
         for fileSystemSynchronizedGroup in fileSystemSynchronizedGroups {
             guard let path = fileSystemSynchronizedGroup.path else { continue }
             let directory = xcodeProj.srcPath.appending(component: path)
-            let membershipExceptions = Set(
-                fileSystemSynchronizedGroup.exceptions
-                    .map { $0.compactMap(\.membershipExceptions).flatMap { $0 } } ?? []
-            )
+            let membershipExceptions = membershipExceptions(for: fileSystemSynchronizedGroup)
 
             let groupResources = try await globFiles(
                 directory: directory,
@@ -463,9 +465,10 @@ struct PBXTargetMapper: PBXTargetMapping {
             guard let path = fileSystemSynchronizedGroup.path else { continue }
             let directory = xcodeProj.srcPath.appending(component: path)
             let membershipExceptions = membershipExceptions(for: fileSystemSynchronizedGroup)
-            let attributesByRelativePath = fileSystemSynchronizedGroup.exceptions?.reduce([:]) { acc, element in
-                acc.merging(element.attributesByRelativePath ?? [:], uniquingKeysWith: { $1 })
-            }
+            let attributesByRelativePath = fileSystemSynchronizedGroup.exceptions?
+                .compactMap { $0 as? PBXFileSystemSynchronizedBuildFileExceptionSet }.reduce([:]) { acc, element in
+                    acc.merging(element.attributesByRelativePath ?? [:], uniquingKeysWith: { $1 })
+                }
 
             let groupFrameworks: [TargetDependency] = try await globFiles(
                 directory: directory,
@@ -500,7 +503,9 @@ struct PBXTargetMapper: PBXTargetMapping {
         for fileSystemSynchronizedGroup in fileSystemSynchronizedGroups {
             guard let path = fileSystemSynchronizedGroup.path else { continue }
             let directory = xcodeProj.srcPath.appending(component: path)
-            for synchronizedBuildFileSystemExceptionSet in fileSystemSynchronizedGroup.exceptions ?? [] {
+            for synchronizedBuildFileSystemExceptionSet in fileSystemSynchronizedGroup.exceptions?
+                .compactMap({ $0 as? PBXFileSystemSynchronizedBuildFileExceptionSet }) ?? []
+            {
                 for publicHeader in synchronizedBuildFileSystemExceptionSet.publicHeaders ?? [] {
                     publicHeaders.append(directory.appending(component: publicHeader))
                 }
@@ -539,6 +544,7 @@ struct PBXTargetMapper: PBXTargetMapping {
     private func membershipExceptions(for fileSystemSynchronizedGroup: PBXFileSystemSynchronizedRootGroup) -> Set<String> {
         Set(
             fileSystemSynchronizedGroup.exceptions
+                .map { $0.compactMap { $0 as? PBXFileSystemSynchronizedBuildFileExceptionSet } }
                 .map { $0.compactMap(\.membershipExceptions).flatMap { $0 } } ?? []
         )
     }

--- a/Tests/XcodeGraphMapperTests/MapperTests/Phases/PBXCopyFilesBuildPhaseMapperTests.swift
+++ b/Tests/XcodeGraphMapperTests/MapperTests/Phases/PBXCopyFilesBuildPhaseMapperTests.swift
@@ -43,7 +43,11 @@ struct PBXCopyFilesBuildPhaseMapperTests {
         let mapper = PBXCopyFilesBuildPhaseMapper()
 
         // When
-        let copyActions = try mapper.map([copyFilesPhase], xcodeProj: xcodeProj)
+        let copyActions = try mapper.map(
+            [copyFilesPhase],
+            fileSystemSynchronizedGroups: [],
+            xcodeProj: xcodeProj
+        )
 
         // Then
         #expect(copyActions.count == 1)
@@ -57,5 +61,71 @@ struct PBXCopyFilesBuildPhaseMapperTests {
         let fileAction = try #require(action.files.first)
         #expect(fileAction.codeSignOnCopy == true)
         #expect(fileAction.path.basename == "MyLibrary.dylib")
+    }
+
+    @Test("Maps copy files actions with a synchronized group")
+    func testMapCopyFilesWithSynchronizedGroup() async throws {
+        // Given
+        let xcodeProj = try await XcodeProj.test(
+            path: "/tmp/TestProject/Project.xcodeproj"
+        )
+        let pbxProj = xcodeProj.pbxproj
+
+        let copyFilesPhase = PBXCopyFilesBuildPhase(
+            dstPath: "XPC Services",
+            dstSubfolderSpec: .productsDirectory,
+            name: "Copy files",
+            files: []
+        )
+        .add(to: pbxProj)
+
+        try PBXNativeTarget.test(
+            name: "App",
+            buildPhases: [copyFilesPhase],
+            productType: .application
+        )
+        .add(to: pbxProj)
+        .add(to: pbxProj.rootObject)
+
+        let mapper = PBXCopyFilesBuildPhaseMapper()
+        let exceptionSet = PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet(
+            buildPhase: copyFilesPhase,
+            membershipExceptions: [
+                "XCPService.xpc",
+            ],
+            attributesByRelativePath: nil
+        )
+        let rootGroup = PBXFileSystemSynchronizedRootGroup(
+            path: "SynchronizedRootGroup",
+            exceptions: [
+                exceptionSet,
+            ]
+        )
+
+        // When
+        let copyActions = try mapper.map(
+            [copyFilesPhase],
+            fileSystemSynchronizedGroups: [
+                rootGroup,
+            ],
+            xcodeProj: xcodeProj
+        )
+
+        // Then
+        #expect(copyActions.count == 1)
+
+        let action = try #require(copyActions.first)
+        #expect(action.name == "Copy files")
+        #expect(action.destination == .productsDirectory)
+        #expect(action.subpath == "XPC Services")
+        #expect(
+            action.files == [
+                .file(
+                    path: "/tmp/TestProject/SynchronizedRootGroup/XCPService.xpc",
+                    condition: nil,
+                    codeSignOnCopy: true
+                ),
+            ]
+        )
     }
 }

--- a/Tests/XcodeGraphMapperTests/MapperTests/Target/PBXTargetMapperTests.swift
+++ b/Tests/XcodeGraphMapperTests/MapperTests/Target/PBXTargetMapperTests.swift
@@ -40,7 +40,7 @@ struct PBXTargetMapperTests: Sendable {
         #expect(mapped.bundleId == "com.example.app")
     }
 
-    @Test("Throws an error if the target is missing a bundle identifier")
+    @Test("Defaults to unknown if the target is missing a bundle identifier")
     func testMapTargetWithMissingBundleId() async throws {
         // Given
         let xcodeProj = try await XcodeProj.test()
@@ -53,15 +53,16 @@ struct PBXTargetMapperTests: Sendable {
         )
         let mapper = PBXTargetMapper()
 
-        // When / Then
-        await #expect(throws: PBXTargetMappingError.missingBundleIdentifier(targetName: "App")) {
-            _ = try await mapper.map(
-                pbxTarget: target,
-                xcodeProj: xcodeProj,
-                projectNativeTargets: [:],
-                packages: []
-            )
-        }
+        // When
+        let mapped = try await mapper.map(
+            pbxTarget: target,
+            xcodeProj: xcodeProj,
+            projectNativeTargets: [:],
+            packages: []
+        )
+
+        // Then
+        #expect(mapped.bundleId == "Unknown")
     }
 
     @Test("Maps a target with environment variables")


### PR DESCRIPTION
Adds support for correctly mapping build phase file references from synchronized groups.

The support for the `PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet` in `XcodeProj` is added via https://github.com/tuist/XcodeProj/pull/894