### PR TITLE
fix: duplicated values in build settings

### DIFF
--- a/Sources/XcodeGraph/Extensions/SettingsDictionary+Extras.swift
+++ b/Sources/XcodeGraph/Extensions/SettingsDictionary+Extras.swift
@@ -31,9 +31,19 @@ extension SettingsDictionary {
             }
             switch oldValue {
             case let .array(values):
-                return .array(values + newValues)
+                return .array(
+                    Array(
+                        Set(values + newValues)
+                    )
+                )
             case let .string(value):
-                return .array(value.split(separator: " ").map(String.init) + newValues)
+                return .array(
+                    Array(
+                        Set(
+                            value.split(separator: " ").map(String.init) + newValues
+                        )
+                    )
+                )
             }
         })
     }

--- a/Tests/XcodeGraphTests/Extensions/SettingsDictionary+ExtrasTests.swift
+++ b/Tests/XcodeGraphTests/Extensions/SettingsDictionary+ExtrasTests.swift
@@ -1,9 +1,46 @@
 import Foundation
-import XCTest
+import Testing
 
 @testable import XcodeGraph
 
-final class SettingsDictionaryExtrasTest: XCTestCase {
+struct SettingsDictionaryExtrasTest {
+    @Test
+    func test_combine_doesNotIncludeDuplicates() {
+        // Given
+        let settings: [String: SettingValue] = [
+            "A": .array(["first value", "second value"]),
+        ]
+
+        // When
+        let got = settings.combine(
+            with: [
+                "A": .array(
+                    [
+                        "first value", "third value",
+                    ]
+                ),
+            ]
+        )
+        .mapValues { value -> SettingValue in
+            switch value {
+            case let .array(values): return .array(values.sorted())
+            default: return value
+            }
+        }
+
+        // Then
+        #expect(
+            got == [
+                "A": .array(
+                    [
+                        "first value", "second value", "third value",
+                    ]
+                ),
+            ]
+        )
+    }
+
+    @Test
     func testOverlay_addsPlatformSpecifierWhenSettingsDiffer() {
         // Given
         var settings: [String: SettingValue] = [
@@ -19,11 +56,13 @@ final class SettingsDictionaryExtrasTest: XCTestCase {
         ], for: .macOS)
 
         // Then
-        XCTAssertEqual(settings, [
-            "A[sdk=macosx*]": "overlayed value",
-            "A": "a value",
-            "B": "b value",
-            "C[sdk=macosx*]": "c value",
-        ])
+        #expect(
+            settings == [
+                "A[sdk=macosx*]": "overlayed value",
+                "A": "a value",
+                "B": "b value",
+                "C[sdk=macosx*]": "c value",
+            ]
+        )
     }
 }


### PR DESCRIPTION
When combining two settings values that are both arrays, we can easily introduce duplicate values. In extreme cases, this leads to thousands of duplicates, causing Xcode to freeze.