### PR TITLE
fix: fix Version decoding

### DIFF
--- a/Sources/XcodeGraph/Models/Version.swift
+++ b/Sources/XcodeGraph/Models/Version.swift
@@ -35,6 +35,17 @@ public struct Version: Hashable, Codable, Sendable {
         self.buildMetadataIdentifiers = buildMetadataIdentifiers
     }
 
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(String.self)
+
+        guard let version = Version(string: value) else {
+            fatalError("\(value) is not a valid version")
+        }
+
+        self = version
+    }
+
     /// Returns the value that Xcode projects use internally.
     public var xcodeStringValue: String {
         "\(major)\(minor)\(patch)"

--- a/Tests/XcodeGraphTests/Models/VersionTests.swift
+++ b/Tests/XcodeGraphTests/Models/VersionTests.swift
@@ -13,4 +13,12 @@ final class VersionTests: XCTestCase {
         // Then
         XCTAssertEqual(got, "123")
     }
+
+    func test_codable() {
+        // Given
+        let version = Version(stringLiteral: "1.2.3")
+
+        // Then
+        XCTAssertCodable(version)
+    }
 }


### PR DESCRIPTION
## 📝 Description

This PR fixes the decoding of the `Version` type.

While the encoding of this type was using a single value container no explicit decoding init was specified. This led to the fact the default synthesised decoding initialiser is used. But this one will expect the full fletched object to be encoded. This leads to decoding errors, like the following: 

```
Error: typeMismatch(Swift.Dictionary<Swift.String, Any>, Swift.DecodingError.Context(codingPath: [
    CodingKeys(stringValue:"projects", intValue: nil),
    _CodingKey(stringValue: "Index 7", intValue: 7),
    CodingKeys(stringValue: "lastUpgradeCheck", intValue: nil)
],
debugDescription: "Expected to decode Dictionary<String, Any> but found a string instead.",
underlyingError: nil)
)
```

This PR now implements a custom decoding initialiser matching the encoding.  
