### PR TITLE
fix: framework not found when name needs to be sanitized

### DIFF
--- a/Sources/XcodeGraphMapper/Mappers/Graph/XcodeGraphMapper.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Graph/XcodeGraphMapper.swift
@@ -208,7 +208,10 @@ public struct XcodeGraphMapper: XcodeGraphMapping {
         }
         let projectNativeTargets: [String: ProjectNativeTarget] = xcodeProjects.reduce(into: [:]) { acc, xcodeProject in
             for nativeTarget in xcodeProject.pbxproj.nativeTargets {
-                acc[nativeTarget.name] = ProjectNativeTarget(
+                let name = Target.sanitizedProductNameFrom(
+                    targetName: nativeTarget.name
+                )
+                acc[name] = ProjectNativeTarget(
                     nativeTarget: nativeTarget,
                     project: xcodeProject
                 )

--- a/Sources/XcodeGraphMapper/Utilities/ProjectNativeTarget.swift
+++ b/Sources/XcodeGraphMapper/Utilities/ProjectNativeTarget.swift
@@ -1,7 +1,7 @@
 import XcodeProj
 
 /// Model representing a `PBXNativeTarget` in a give `XcodeProj`
-struct ProjectNativeTarget {
+struct ProjectNativeTarget: Equatable {
     let nativeTarget: PBXNativeTarget
     let project: XcodeProj
 }

--- a/Tests/XcodeGraphMapperTests/MapperTests/Graph/XcodeGraphMapperTests.swift
+++ b/Tests/XcodeGraphMapperTests/MapperTests/Graph/XcodeGraphMapperTests.swift
@@ -62,6 +62,56 @@ struct XcodeGraphMapperTests {
         #expect(graph.workspace.name == "Workspace")
     }
 
+    @Test("Maps a project with sanitizable target names")
+    func testProjectWithSanitizableTargetNames() async throws {
+        // Given
+        let pbxProj = PBXProj()
+
+        let xcodeProj = try await XcodeProj.test(
+            projectName: "SingleProject",
+            pbxProj: pbxProj
+        )
+
+        let projectMapper = MockPBXProjectMapping()
+        given(projectMapper)
+            .map(
+                xcodeProj: .any,
+                projectNativeTargets: .any
+            )
+            .willReturn(
+                .test()
+            )
+
+        // Add a single target to the project
+        try PBXNativeTarget.test(
+            name: "App-With-Dash",
+            productType: .application
+        )
+        .add(to: pbxProj)
+        .add(to: pbxProj.rootObject)
+
+        try xcodeProj.write(path: xcodeProj.path!)
+        let mapper = XcodeGraphMapper(
+            projectMapper: projectMapper
+        )
+        // When
+        _ = try await mapper.buildGraph(from: .project(xcodeProj))
+
+        // Then
+        verify(projectMapper)
+            .map(
+                xcodeProj: .any,
+                projectNativeTargets: .matching(
+                    {
+                        $0.keys.map { $0 } == [
+                            "App_With_Dash",
+                        ]
+                    }
+                )
+            )
+            .called(1)
+    }
+
     @Test("Maps a workspace with multiple projects into a single graph")
     func testWorkspaceGraphMultipleProjects() async throws {
         // Given
@@ -359,10 +409,5 @@ struct XcodeGraphMapperTests {
                 ],
             ]
         )
-//        // Verify dependencies are mapped
-//        let targetDep = GraphDependency.target(name: "AFramework", path: xcodeProj.srcPath)
-//        let expectedDependency = try #require(graph.dependencies.first?.value)
-
-//        #expect(expectedDependency == [targetDep])
     }
 }


### PR DESCRIPTION
When finding frameworks across all native targets using the `projectNativeTargets` parameter, we need to try match the sanitized variant as that's how a framework target is referenced in the frameworks build phase.

For example, an `App-With-Dash` target will be included in the frameworks build phase as `App_With_Dash`.