### PR TITLE
feat: support dynamic file list paths

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "377d0890e78ed330d863806cbf4cdc28ce4dc14faeb68c692140ca84153f49ff",
+  "originHash" : "11c91097a7d3815aa19aa8bdc65446d1e51f2b556e7afb8fdff27ce1384ed4b6",
   "pins" : [
     {
       "identity" : "aexml",
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj",
       "state" : {
-        "revision" : "142b7ea0a087eabf4d12207302a185a0e9d4659b",
-        "version" : "8.27.0"
+        "revision" : "cbd622399d845f7686ac96c5110cea5a784758a3",
+        "version" : "8.27.1"
       }
     },
     {

--- a/Sources/XcodeGraph/Models/TargetScript.swift
+++ b/Sources/XcodeGraph/Models/TargetScript.swift
@@ -74,13 +74,13 @@ public struct TargetScript: Equatable, Codable, Sendable {
     public let inputPaths: [String]
 
     /// List of input filelist paths
-    public let inputFileListPaths: [AbsolutePath]
+    public let inputFileListPaths: [String]
 
     /// List of output file paths
     public let outputPaths: [String]
 
     /// List of output filelist paths
-    public let outputFileListPaths: [AbsolutePath]
+    public let outputFileListPaths: [String]
 
     /// Show environment variables in the logs
     public var showEnvVarsInLog: Bool
@@ -117,9 +117,9 @@ public struct TargetScript: Equatable, Codable, Sendable {
         order: Order,
         script: Script = .embedded(""),
         inputPaths: [String] = [],
-        inputFileListPaths: [AbsolutePath] = [],
+        inputFileListPaths: [String] = [],
         outputPaths: [String] = [],
-        outputFileListPaths: [AbsolutePath] = [],
+        outputFileListPaths: [String] = [],
         showEnvVarsInLog: Bool = true,
         basedOnDependencyAnalysis: Bool? = nil,
         runForInstallBuildsOnly: Bool = false,

--- a/Sources/XcodeGraphMapper/Mappers/Phases/PBXScriptsBuildPhaseMapper.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Phases/PBXScriptsBuildPhaseMapper.swift
@@ -50,14 +50,6 @@ struct PBXScriptsBuildPhaseMapper: PBXScriptsBuildPhaseMapping {
             return nil
         }
 
-        let inputFileListPaths = try scriptPhase.inputFileListPaths?.compactMap {
-            try AbsolutePath(validating: $0)
-        } ?? []
-
-        let outputFileListPaths = try scriptPhase.outputFileListPaths?.compactMap {
-            try AbsolutePath(validating: $0)
-        } ?? []
-
         let dependencyFile = try scriptPhase.dependencyFile.map {
             try AbsolutePath(validating: $0)
         }
@@ -67,9 +59,9 @@ struct PBXScriptsBuildPhaseMapper: PBXScriptsBuildPhaseMapping {
             order: determineScriptOrder(buildPhases: buildPhases, scriptPhase: scriptPhase),
             script: .embedded(shellScript),
             inputPaths: scriptPhase.inputPaths,
-            inputFileListPaths: inputFileListPaths,
+            inputFileListPaths: scriptPhase.inputFileListPaths ?? [],
             outputPaths: scriptPhase.outputPaths,
-            outputFileListPaths: outputFileListPaths,
+            outputFileListPaths: scriptPhase.outputFileListPaths ?? [],
             showEnvVarsInLog: scriptPhase.showEnvVarsInLog,
             basedOnDependencyAnalysis: scriptPhase.alwaysOutOfDate ? false : nil,
             runForInstallBuildsOnly: scriptPhase.runOnlyForDeploymentPostprocessing,

--- a/Tests/XcodeGraphMapperTests/MapperTests/Phases/PBXScriptsBuildPhaseMapperTests.swift
+++ b/Tests/XcodeGraphMapperTests/MapperTests/Phases/PBXScriptsBuildPhaseMapperTests.swift
@@ -15,7 +15,8 @@ struct PBXScriptsBuildPhaseMapperTests {
             name: "Run Script",
             shellScript: "echo Hello",
             inputPaths: ["$(SRCROOT)/input.txt"],
-            outputPaths: ["$(DERIVED_FILE_DIR)/output.txt"]
+            outputPaths: ["$(DERIVED_FILE_DIR)/output.txt"],
+            inputFileListPaths: ["${PODS_ROOT}/${CONFIGURATION}/file-list.xcfilelist"]
         )
         .add(to: pbxProj)
 
@@ -39,6 +40,7 @@ struct PBXScriptsBuildPhaseMapperTests {
         #expect(script.script == .embedded("echo Hello"))
         #expect(script.inputPaths == ["$(SRCROOT)/input.txt"])
         #expect(script.outputPaths == ["$(DERIVED_FILE_DIR)/output.txt"])
+        #expect(script.inputFileListPaths == ["${PODS_ROOT}/${CONFIGURATION}/file-list.xcfilelist"])
     }
 
     @Test("Maps raw script build phases not covered by other categories")


### PR DESCRIPTION
File list paths in build phases can be dynamic when referenced with build variables, such as `${PODS_ROOT}/Target Support Files/Pods-App/Pods-App-frameworks-${CONFIGURATION}-input-files.xcfilelist` in the case of Cocoapods projects.

We should align `inputFileListPaths` and `outputFileListPaths` with `inputPaths` and `outputPaths` types which are `[String]`.

This is minor breaking change.

I've also considered preserving the absolute paths and evaluating the build settings – but when the file list is referenced with a configuration-specific build setting variable, we could never actually resolve the right path.

Changing the type to `[String]` feels like the only correct way of going about this.