### PR TITLE
revert: duplicated values in build settings

### DIFF
--- a/Sources/XcodeGraph/Extensions/SettingsDictionary+Extras.swift
+++ b/Sources/XcodeGraph/Extensions/SettingsDictionary+Extras.swift
@@ -31,19 +31,9 @@ extension SettingsDictionary {
             }
             switch oldValue {
             case let .array(values):
-                return .array(
-                    Array(
-                        Set(values + newValues)
-                    )
-                )
+                return .array(values + newValues)
             case let .string(value):
-                return .array(
-                    Array(
-                        Set(
-                            value.split(separator: " ").map(String.init) + newValues
-                        )
-                    )
-                )
+                return .array(value.split(separator: " ").map(String.init) + newValues)
             }
         })
     }

--- a/Tests/XcodeGraphTests/Extensions/SettingsDictionary+ExtrasTests.swift
+++ b/Tests/XcodeGraphTests/Extensions/SettingsDictionary+ExtrasTests.swift
@@ -1,46 +1,9 @@
 import Foundation
-import Testing
+import XCTest
 
 @testable import XcodeGraph
 
-struct SettingsDictionaryExtrasTest {
-    @Test
-    func test_combine_doesNotIncludeDuplicates() {
-        // Given
-        let settings: [String: SettingValue] = [
-            "A": .array(["first value", "second value"]),
-        ]
-
-        // When
-        let got = settings.combine(
-            with: [
-                "A": .array(
-                    [
-                        "first value", "third value",
-                    ]
-                ),
-            ]
-        )
-        .mapValues { value -> SettingValue in
-            switch value {
-            case let .array(values): return .array(values.sorted())
-            default: return value
-            }
-        }
-
-        // Then
-        #expect(
-            got == [
-                "A": .array(
-                    [
-                        "first value", "second value", "third value",
-                    ]
-                ),
-            ]
-        )
-    }
-
-    @Test
+final class SettingsDictionaryExtrasTest: XCTestCase {
     func testOverlay_addsPlatformSpecifierWhenSettingsDiffer() {
         // Given
         var settings: [String: SettingValue] = [
@@ -56,13 +19,11 @@ struct SettingsDictionaryExtrasTest {
         ], for: .macOS)
 
         // Then
-        #expect(
-            settings == [
-                "A[sdk=macosx*]": "overlayed value",
-                "A": "a value",
-                "B": "b value",
-                "C[sdk=macosx*]": "c value",
-            ]
-        )
+        XCTAssertEqual(settings, [
+            "A[sdk=macosx*]": "overlayed value",
+            "A": "a value",
+            "B": "b value",
+            "C[sdk=macosx*]": "c value",
+        ])
     }
 }


### PR DESCRIPTION
This reverts commit db41514648f80f90882a2afee3daad8bb573c235.

We can't deduplicate all build settings when they are combined. In some cases, some values _have_ to be duplicated, such as each Swift C-related flag needs to be prefixed with its own `-Xcc`.