### PR TITLE
feat: improve error message when PBXBuildFile.file reference is not found

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "11c91097a7d3815aa19aa8bdc65446d1e51f2b556e7afb8fdff27ce1384ed4b6",
+  "originHash" : "e00b9b258083e5d180326ee4f3fedbcfea7db4ae854a2bf6745abd5db9a73971",
   "pins" : [
     {
       "identity" : "aexml",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/Command.git",
       "state" : {
-        "revision" : "07846291097a593de29846c0083b758471071cdf",
-        "version" : "0.12.2"
+        "revision" : "079a7803b581d3022469b3a331bccd51d48d2fc0",
+        "version" : "0.13.0"
       }
     },
     {

--- a/Sources/XcodeGraphMapper/Mappers/Phases/PBXFrameworksBuildPhaseMapper.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Phases/PBXFrameworksBuildPhaseMapper.swift
@@ -57,7 +57,12 @@ struct PBXFrameworksBuildPhaseMapper: PBXFrameworksBuildPhaseMapping {
                 condition: nil
             )
         }
-        let fileRef = try buildFile.file.throwing(PBXFrameworksBuildPhaseMappingError.missingFileReference)
+        let fileRef = try buildFile.file.throwing(
+            PBXFrameworksBuildPhaseMappingError.missingFileReference(
+                buildFile.uuid,
+                xcodeProj.projectPath.appending(component: "project.pbxproj")
+            )
+        )
         if let path = fileRef.path {
             let name = path.replacingOccurrences(of: ".framework", with: "")
             let linkingStatus: LinkingStatus = (buildFile.settings?["ATTRIBUTES"] as? [String])?
@@ -98,16 +103,16 @@ struct PBXFrameworksBuildPhaseMapper: PBXFrameworksBuildPhaseMapping {
 
 /// Errors that may occur when mapping framework build phase files.
 enum PBXFrameworksBuildPhaseMappingError: Error, LocalizedError {
-    case missingFileReference
+    case missingFileReference(String, AbsolutePath)
     case missingFilePath(name: String?)
 
     var errorDescription: String? {
         switch self {
-        case .missingFileReference:
-            return "Missing `PBXBuildFile.file` reference."
+        case let .missingFileReference(buildFileUUID, pbxprojPath):
+            return "Missing 'PBXBuildFile.file' reference for \(buildFileUUID) id. Make sure an element with that id is present in the \(pbxprojPath.pathString) file."
         case let .missingFilePath(name):
             let fileName = name ?? "Unknown"
-            return "Missing or invalid file path for `PBXBuildFile`: \(fileName)."
+            return "Missing or invalid file path for 'PBXBuildFile': \(fileName)."
         }
     }
 }

--- a/Tests/XcodeGraphMapperTests/MapperTests/Graph/XcodeGraphMapperTests.swift
+++ b/Tests/XcodeGraphMapperTests/MapperTests/Graph/XcodeGraphMapperTests.swift
@@ -285,7 +285,7 @@ struct XcodeGraphMapperTests {
             pbxProj: pbxProj
         )
 
-        let appTarget = try PBXNativeTarget.test(
+        try PBXNativeTarget.test(
             name: "App",
             buildConfigurationList: configurationList,
             buildPhases: [],


### PR DESCRIPTION
As raised [here](https://community.tuist.dev/t/selective-testing-for-non-generated-projects/381/7?u=marekfort), the current error message for when a `PBXBuildFile.file` reference is not found doesn't provide any extra details for what's missing.

Current error message:
```
Missing `PBXBuildFile.file` reference.
```

New error message example:
```
Missing 'PBXBuildFile.file' reference for F806E10B2D54DD7C0058A673 id. Make sure an element with that id is present in the /Users/marekfort/Developer/tuist/fixtures/xcode_project_with_tests/App.xcodeproj/project.pbxproj file
```

The error message is relatively low-level, but I'd rather go low-level than provide a high-level error message that doesn't provide any insights into what the error might be.