### PR TITLE
[feedback wanted] refactor: Limit `BuildSettings` usage to only `String` and `[String]` values

### DIFF
--- a/Sources/XcodeGraphMapper/Mappers/Settings/BuildSettings.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Settings/BuildSettings.swift
@@ -3,20 +3,8 @@ import Foundation
 /// Keys representing various build settings that may appear in an Xcode project or workspace configuration.
 enum BuildSettingKey: String {
     case sdkroot = "SDKROOT"
-    case compilerFlags = "COMPILER_FLAGS"
-    case attributes = "ATTRIBUTES"
-    case environmentVariables = "ENVIRONMENT_VARIABLES"
     case codeSignOnCopy = "CODE_SIGN_ON_COPY"
-    case dependencyFile = "DEPENDENCY_FILE"
-    case inputPaths = "INPUT_PATHS"
-    case outputPaths = "OUTPUT_PATHS"
-    case showEnvVarsInLog = "SHOW_ENV_VARS_IN_LOG"
-    case shellPath = "SHELL_PATH"
-    case launchArguments = "LAUNCH_ARGUMENTS"
-    case tags = "TAGS"
-    case mergedBinaryType = "MERGED_BINARY_TYPE"
-    case prune = "PRUNE"
-    case mergeable = "MERGEABLE"
+
     case productBundleIdentifier = "PRODUCT_BUNDLE_IDENTIFIER"
     case infoPlistFile = "INFOPLIST_FILE"
     case codeSignEntitlements = "CODE_SIGN_ENTITLEMENTS"
@@ -26,6 +14,30 @@ enum BuildSettingKey: String {
     case tvOSDeploymentTarget = "TVOS_DEPLOYMENT_TARGET"
     case visionOSDeploymentTarget = "VISIONOS_DEPLOYMENT_TARGET"
 }
+
+enum TuistBuildSettingKey: String {
+    case launchArguments = "LAUNCH_ARGUMENTS" // Used for scheme generation
+    case environmentVariables = "ENVIRONMENT_VARIABLES" // Used for scheme generation
+    case tags = "TAGS" // metadata
+    case prune = "PRUNE"
+    case mergeable = "MERGEABLE" // Mergable library build settings generation
+    case mergedBinaryType = "MERGED_BINARY_TYPE" // Default settings configuration for mergable libraries
+}
+
+enum TuistScriptSettingKey: String {
+    case showEnvVarsInLog = "SHOW_ENV_VARS_IN_LOG"
+    case shellPath = "SHELL_PATH"
+    case dependencyFile = "DEPENDENCY_FILE"
+    case inputPaths = "INPUT_PATHS"
+    case outputPaths = "OUTPUT_PATHS"
+}
+
+enum BuildFileSettings: String {
+    case compilerFlags = "COMPILER_FLAGS"
+    case attributes = "ATTRIBUTES"
+}
+
+
 
 /// A protocol representing a type that can parse a build setting value from a generic `Any`.
 protocol BuildSettingValue {
@@ -45,20 +57,6 @@ enum BuildSettingStringArray: BuildSettingValue {
     static func parse(_ any: Any) -> [String]? {
         let arr = any as? [Any]
         return arr?.compactMap { $0 as? String }
-    }
-}
-
-/// A type that parses build settings as booleans.
-enum BuildSettingBool: BuildSettingValue {
-    static func parse(_ any: Any) -> Bool? {
-        any as? Bool
-    }
-}
-
-/// A type that parses build settings as dictionaries of strings to strings.
-enum BuildSettingStringDict: BuildSettingValue {
-    static func parse(_ any: Any) -> [String: String]? {
-        any as? [String: String]
     }
 }
 
@@ -86,15 +84,5 @@ extension [String: Any] {
     /// Retrieves an array of strings for the given build setting key.
     func stringArray(for key: BuildSettingKey) -> [String]? {
         extractBuildSetting(key, as: BuildSettingStringArray.self)
-    }
-
-    /// Retrieves a boolean value for the given build setting key.
-    func bool(for key: BuildSettingKey) -> Bool? {
-        extractBuildSetting(key, as: BuildSettingBool.self)
-    }
-
-    /// Retrieves a dictionary of strings for the given build setting key.
-    func stringDict(for key: BuildSettingKey) -> [String: String]? {
-        extractBuildSetting(key, as: BuildSettingStringDict.self)
     }
 }

--- a/Sources/XcodeGraphMapper/Mappers/Targets/PBXTarget+BuildSettings.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Targets/PBXTarget+BuildSettings.swift
@@ -6,12 +6,14 @@ import XcodeProj
 extension PBXTarget {
     enum EnvironmentExtractor {
         static func extract(from buildSettings: BuildSettings) -> [String: EnvironmentVariable] {
-            guard let envVars = buildSettings.stringDict(for: .environmentVariables) else {
-                return [:]
-            }
-            return envVars.reduce(into: [:]) { result, pair in
-                result[pair.key] = EnvironmentVariable(value: pair.value, isEnabled: true)
-            }
+//            guard let envVars = buildSettings.stringDict(for: .environmentVariables) else {
+//                return [:]
+//            }
+//            return envVars.reduce(into: [:]) { result, pair in
+//                result[pair.key] = EnvironmentVariable(value: pair.value, isEnabled: true)
+//            }
+//            
+            [:]
         }
     }
 

--- a/Sources/XcodeGraphMapper/Mappers/Targets/PBXTarget+GraphMapping.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Targets/PBXTarget+GraphMapping.swift
@@ -18,45 +18,45 @@ extension PBXTarget {
         buildPhases.compactMap { $0 as? PBXCopyFilesBuildPhase }
     }
 
-    func launchArguments() throws -> [LaunchArgument] {
-        guard let buildConfigList = buildConfigurationList else { return [] }
-        var launchArguments: [LaunchArgument] = []
-        for buildConfig in buildConfigList.buildConfigurations {
-            if let args = buildConfig.buildSettings.stringArray(for: .launchArguments) {
-                launchArguments.append(contentsOf: args.map { LaunchArgument(name: $0, isEnabled: true) })
-            }
-        }
-        return launchArguments.uniqued()
-    }
+//    func launchArguments() throws -> [LaunchArgument] {
+//        guard let buildConfigList = buildConfigurationList else { return [] }
+//        var launchArguments: [LaunchArgument] = []
+//        for buildConfig in buildConfigList.buildConfigurations {
+//            if let args = buildConfig.buildSettings.stringArray(for: .launchArguments) {
+//                launchArguments.append(contentsOf: args.map { LaunchArgument(name: $0, isEnabled: true) })
+//            }
+//        }
+//        return launchArguments.uniqued()
+//    }
 
-    func prune() throws -> Bool {
-        debugBuildSettings.bool(for: .prune) ?? false
-    }
+//    func prune() throws -> Bool {
+//        debugBuildSettings.bool(for: .prune) ?? false
+//    }
 
     func mergedBinaryType() throws -> MergedBinaryType {
         let mergedBinaryTypeString = debugBuildSettings.string(for: .mergedBinaryType)
         return mergedBinaryTypeString == "automatic" ? .automatic : .disabled
     }
 
-    func mergeable() throws -> Bool {
-        debugBuildSettings.bool(for: .mergeable) ?? false
-    }
+//    func mergeable() throws -> Bool {
+//        debugBuildSettings.bool(for: .mergeable) ?? false
+//    }
 
     func onDemandResourcesTags() throws -> OnDemandResourcesTags? {
         // Currently returns nil, could be extended if needed
         return nil
     }
 
-    func metadata() throws -> TargetMetadata {
-        var tags: Set<String> = []
-        for buildConfig in buildConfigurationList?.buildConfigurations ?? [] {
-            if let tagsString = buildConfig.buildSettings.string(for: .tags) {
-                let extractedTags = tagsString
-                    .split(separator: ",")
-                    .map { $0.trimmingCharacters(in: .whitespaces) }
-                tags.formUnion(extractedTags)
-            }
-        }
-        return .metadata(tags: tags)
-    }
+//    func metadata() throws -> TargetMetadata {
+//        var tags: Set<String> = []
+//        for buildConfig in buildConfigurationList?.buildConfigurations ?? [] {
+//            if let tagsString = buildConfig.buildSettings.string(for: .tags) {
+//                let extractedTags = tagsString
+//                    .split(separator: ",")
+//                    .map { $0.trimmingCharacters(in: .whitespaces) }
+//                tags.formUnion(extractedTags)
+//            }
+//        }
+//        return .metadata(tags: tags)
+//    }
 }

--- a/Sources/XcodeGraphMapper/Mappers/Targets/PBXTargetMapper.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Targets/PBXTargetMapper.swift
@@ -186,8 +186,8 @@ struct PBXTargetMapper: PBXTargetMapping {
         let buildRules = try pbxTarget.buildRules.compactMap { try buildRuleMapper.map($0) }
 
         // Environment & Launch
-        let environmentVariables = pbxTarget.extractEnvironmentVariables()
-        let launchArguments = try pbxTarget.launchArguments()
+//        let environmentVariables = pbxTarget.extractEnvironmentVariables()
+//        let launchArguments = try pbxTarget.launchArguments()
 
         // Files group
         let filesGroup = try extractFilesGroup(from: pbxTarget, xcodeProj: xcodeProj)
@@ -196,11 +196,11 @@ struct PBXTargetMapper: PBXTargetMapping {
         let playgrounds = try extractPlaygrounds(from: pbxTarget, xcodeProj: xcodeProj)
 
         // Misc
-        let prune = try pbxTarget.prune()
-        let mergedBinaryType = try pbxTarget.mergedBinaryType()
-        let mergeable = try pbxTarget.mergeable()
+//        let prune = try pbxTarget.prune()
+//        let mergedBinaryType = try pbxTarget.mergedBinaryType()
+//        let mergeable = try pbxTarget.mergeable()
         let onDemandResourcesTags = try pbxTarget.onDemandResourcesTags()
-        let metadata = try pbxTarget.metadata()
+//        let metadata = try pbxTarget.metadata()
 
         // Dependencies
         let projectNativeTargets = try pbxTarget.dependencies.compactMap {
@@ -225,19 +225,19 @@ struct PBXTargetMapper: PBXTargetMapping {
             headers: headers,
             coreDataModels: coreDataModels,
             scripts: scripts,
-            environmentVariables: environmentVariables,
-            launchArguments: launchArguments,
+//            environmentVariables: environmentVariables,
+//            launchArguments: launchArguments,
             filesGroup: filesGroup,
             dependencies: allDependencies,
             rawScriptBuildPhases: rawScriptBuildPhases,
             playgrounds: playgrounds,
             additionalFiles: additionalFiles,
             buildRules: buildRules,
-            prune: prune,
-            mergedBinaryType: mergedBinaryType,
-            mergeable: mergeable,
+//            prune: false,
+//            mergedBinaryType: mergedBinaryType,
+//            mergeable: mergeable,
             onDemandResourcesTags: onDemandResourcesTags,
-            metadata: metadata,
+//            metadata: metadata
             packages: packages
         )
     }


### PR DESCRIPTION
In working on https://github.com/tuist/XcodeProj/pull/903 i've found that build settings defined in project files are always deserialized and `String` and `[String]` types.  Other types like `Bool` or `Dictionary` are not representable within build settings.  Even for boolean settings, Xcode encodes and decodes the strings `"YES"` `"NO"`.   

Secondarily, there are some things within `BuildSettings.swift` that are specific to tuist behavior like default build settings for mergable libraries, and scheme generation.  I'm not sure how these are intended to be used but as they are not part of a standard `xcodeproj` I don't believe we want to be attempting to read tuist value that are put into build settings.  

Opening this PR to start a conversation on the path forward related to these two topics.
