### PR TITLE
fix: skip mapping aggregate targets

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e00b9b258083e5d180326ee4f3fedbcfea7db4ae854a2bf6745abd5db9a73971",
+  "originHash" : "fc72c66a6cff23618311dcc542ac7e97cc291d309abdc7587911390ff07d6146",
   "pins" : [
     {
       "identity" : "aexml",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/p-x9/MachOKit",
       "state" : {
-        "revision" : "518e8e1aca7ee64b87b08ecec5f7cad2a63b8efd",
-        "version" : "0.28.0"
+        "revision" : "30b56f12a448137123c17b4f9b67ee867baecc86",
+        "version" : "0.29.0"
       }
     },
     {
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj",
       "state" : {
-        "revision" : "cbd622399d845f7686ac96c5110cea5a784758a3",
-        "version" : "8.27.1"
+        "revision" : "7cb7fbe091b3feb087bb179c445fb96b4fa10982",
+        "version" : "8.27.2"
       }
     },
     {

--- a/Sources/XcodeGraphMapper/Mappers/Project/PBXProjectMapper.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Project/PBXProjectMapper.swift
@@ -66,7 +66,8 @@ struct PBXProjectMapper: PBXProjectMapping {
         let localPackagePaths = try await collectAllPackages(from: pbxProject.mainGroup, xcodeProj: xcodeProj)
 
         // Map PBXTargets to domain Targets
-        let targets = try await withThrowingTaskGroup(of: Target.self, returning: [Target].self) { taskGroup in
+        let targets = try await withThrowingTaskGroup(of: Target?.self, returning: [Target].self) { taskGroup in
+            let projectNativeTargets = projectNativeTargets
             for pbxTarget in pbxProject.targets {
                 taskGroup.addTask {
                     try await targetMapper.map(
@@ -80,7 +81,9 @@ struct PBXProjectMapper: PBXProjectMapping {
 
             var targets: [Target] = []
             for try await target in taskGroup {
-                targets.append(target)
+                if let target {
+                    targets.append(target)
+                }
             }
 
             return targets

--- a/Sources/XcodeGraphMapper/Mappers/Targets/PBXTargetMapper.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Targets/PBXTargetMapper.swift
@@ -49,7 +49,7 @@ protocol PBXTargetMapping {
         xcodeProj: XcodeProj,
         projectNativeTargets: [String: ProjectNativeTarget],
         packages: [AbsolutePath]
-    ) async throws -> Target
+    ) async throws -> Target?
 }
 
 // swiftlint:disable function_body_length
@@ -102,7 +102,11 @@ struct PBXTargetMapper: PBXTargetMapping {
         xcodeProj: XcodeProj,
         projectNativeTargets: [String: ProjectNativeTarget],
         packages: [AbsolutePath]
-    ) async throws -> Target {
+    ) async throws -> Target? {
+        // `XcodeGraph` currently doesn't support representing aggregate targets
+        if pbxTarget is PBXAggregateTarget {
+            return nil
+        }
         let platform = try pbxTarget.platform()
         let deploymentTargets = pbxTarget.deploymentTargets()
         let productType = pbxTarget.productType?.mapProductType()

--- a/Tests/XcodeGraphMapperTests/MapperTests/Target/PBXTargetMapperTests.swift
+++ b/Tests/XcodeGraphMapperTests/MapperTests/Target/PBXTargetMapperTests.swift
@@ -26,11 +26,13 @@ struct PBXTargetMapperTests: Sendable {
         // When
         let mapper = PBXTargetMapper()
 
-        let mapped = try await mapper.map(
-            pbxTarget: target,
-            xcodeProj: xcodeProj,
-            projectNativeTargets: [:],
-            packages: []
+        let mapped = try #require(
+            try await mapper.map(
+                pbxTarget: target,
+                xcodeProj: xcodeProj,
+                projectNativeTargets: [:],
+                packages: []
+            )
         )
 
         // Then
@@ -54,11 +56,13 @@ struct PBXTargetMapperTests: Sendable {
         let mapper = PBXTargetMapper()
 
         // When
-        let mapped = try await mapper.map(
-            pbxTarget: target,
-            xcodeProj: xcodeProj,
-            projectNativeTargets: [:],
-            packages: []
+        let mapped = try #require(
+            try await mapper.map(
+                pbxTarget: target,
+                xcodeProj: xcodeProj,
+                projectNativeTargets: [:],
+                packages: []
+            )
         )
 
         // Then
@@ -81,11 +85,13 @@ struct PBXTargetMapperTests: Sendable {
         let mapper = PBXTargetMapper()
 
         // When
-        let mapped = try await mapper.map(
-            pbxTarget: target,
-            xcodeProj: xcodeProj,
-            projectNativeTargets: [:],
-            packages: []
+        let mapped = try #require(
+            try await mapper.map(
+                pbxTarget: target,
+                xcodeProj: xcodeProj,
+                projectNativeTargets: [:],
+                packages: []
+            )
         )
 
         // Then
@@ -110,11 +116,13 @@ struct PBXTargetMapperTests: Sendable {
         let mapper = PBXTargetMapper()
 
         // When
-        let mapped = try await mapper.map(
-            pbxTarget: target,
-            xcodeProj: xcodeProj,
-            projectNativeTargets: [:],
-            packages: []
+        let mapped = try #require(
+            try await mapper.map(
+                pbxTarget: target,
+                xcodeProj: xcodeProj,
+                projectNativeTargets: [:],
+                packages: []
+            )
         )
 
         // Then
@@ -151,11 +159,13 @@ struct PBXTargetMapperTests: Sendable {
         let mapper = PBXTargetMapper()
 
         // When
-        let mapped = try await mapper.map(
-            pbxTarget: target,
-            xcodeProj: xcodeProj,
-            projectNativeTargets: [:],
-            packages: []
+        let mapped = try #require(
+            try await mapper.map(
+                pbxTarget: target,
+                xcodeProj: xcodeProj,
+                projectNativeTargets: [:],
+                packages: []
+            )
         )
 
         // Then
@@ -243,13 +253,15 @@ struct PBXTargetMapperTests: Sendable {
             )
 
             // When
-            let mapped = try await mapper.map(
-                pbxTarget: target,
-                xcodeProj: xcodeProj,
-                projectNativeTargets: [:],
-                packages: [
-                    packagePath,
-                ]
+            let mapped = try #require(
+                try await mapper.map(
+                    pbxTarget: target,
+                    xcodeProj: xcodeProj,
+                    projectNativeTargets: [:],
+                    packages: [
+                        packagePath,
+                    ]
+                )
             )
 
             // Then
@@ -331,7 +343,7 @@ struct PBXTargetMapperTests: Sendable {
         )
 
         // Then
-        #expect(mapped.metadata.tags == Set(["tag1", "tag2", "tag3"]))
+        #expect(mapped?.metadata.tags == Set(["tag1", "tag2", "tag3"]))
     }
 
     @Test("Maps entitlements when CODE_SIGN_ENTITLEMENTS is set")
@@ -389,7 +401,7 @@ struct PBXTargetMapperTests: Sendable {
         )
 
         // Then
-        #expect(mapped.entitlements == .file(
+        #expect(mapped?.entitlements == .file(
             path: entitlementsPath,
             configuration: BuildConfiguration(name: "Debug", variant: .debug)
         ))
@@ -462,13 +474,36 @@ struct PBXTargetMapperTests: Sendable {
 
         // Then
         #expect({
-            switch mapped.infoPlist {
+            switch mapped?.infoPlist {
             case let .file(path, _):
                 return path == plistPath
             default:
                 return false
             }
         }() == true)
+    }
+
+    @Test
+    func testMapAggregateTarget() async throws {
+        // Given
+        let xcodeProj = try await XcodeProj.test()
+        let target = PBXAggregateTarget(
+            name: "App"
+        )
+
+        try xcodeProj.write(path: xcodeProj.path!)
+        let mapper = PBXTargetMapper()
+
+        // When
+        let mapped = try await mapper.map(
+            pbxTarget: target,
+            xcodeProj: xcodeProj,
+            projectNativeTargets: [:],
+            packages: []
+        )
+
+        // Then
+        #expect(mapped == nil)
     }
 
     // MARK: - Helper Methods


### PR DESCRIPTION
As [reported](https://community.tuist.dev/t/selective-testing-for-non-generated-projects/381/9?u=marekfort) by @KaiOelfke, mapping aggregate targets is failing as we're assuming they have some properties that only `PBXNativeTarget`s have, such as a list of supported destinations.

Since `XcodeGraph` doesn't currently support aggregate targets, we will, for now, skip mapping these completely.

I flagged an [issue](https://github.com/tuist/XcodeGraph/issues/141) to eventually add support for these targets, so the conversion from XcodeProj to XcodeGraph is not lossy.