### PR TITLE
fix: mapping fails when bundle product name differs from target name

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fc72c66a6cff23618311dcc542ac7e97cc291d309abdc7587911390ff07d6146",
+  "originHash" : "903b6688321bae457eebe89dd170b8e84c2b492ea8715d843afaaaa1a64c58b5",
   "pins" : [
     {
       "identity" : "aexml",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/p-x9/MachOKit",
       "state" : {
-        "revision" : "30b56f12a448137123c17b4f9b67ee867baecc86",
-        "version" : "0.29.0"
+        "revision" : "7ea55264554310709a4669091be21e5b5423aa44",
+        "version" : "0.29.1"
       }
     },
     {
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj",
       "state" : {
-        "revision" : "7cb7fbe091b3feb087bb179c445fb96b4fa10982",
-        "version" : "8.27.2"
+        "revision" : "02bc2dd6224aa59147941d85fdc45a7677af62f6",
+        "version" : "8.27.3"
       }
     },
     {

--- a/Sources/XcodeGraphMapper/Mappers/Graph/XcodeGraphMapper.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Graph/XcodeGraphMapper.swift
@@ -208,8 +208,8 @@ public struct XcodeGraphMapper: XcodeGraphMapping {
         }
         let projectNativeTargets: [String: ProjectNativeTarget] = xcodeProjects.reduce(into: [:]) { acc, xcodeProject in
             for nativeTarget in xcodeProject.pbxproj.nativeTargets.sorted(by: { $0.name > $1.name }) {
-                let name = nativeTarget.productName ?? Target.sanitizedProductNameFrom(
-                    targetName: nativeTarget.name
+                let name = Target.sanitizedProductNameFrom(
+                    targetName: nativeTarget.productName ?? nativeTarget.name
                 )
                 acc[name] = ProjectNativeTarget(
                     nativeTarget: nativeTarget,

--- a/Sources/XcodeGraphMapper/Mappers/Graph/XcodeGraphMapper.swift
+++ b/Sources/XcodeGraphMapper/Mappers/Graph/XcodeGraphMapper.swift
@@ -207,8 +207,8 @@ public struct XcodeGraphMapper: XcodeGraphMapping {
             try XcodeProj(pathString: $0.pathString)
         }
         let projectNativeTargets: [String: ProjectNativeTarget] = xcodeProjects.reduce(into: [:]) { acc, xcodeProject in
-            for nativeTarget in xcodeProject.pbxproj.nativeTargets {
-                let name = Target.sanitizedProductNameFrom(
+            for nativeTarget in xcodeProject.pbxproj.nativeTargets.sorted(by: { $0.name > $1.name }) {
+                let name = nativeTarget.productName ?? Target.sanitizedProductNameFrom(
                     targetName: nativeTarget.name
                 )
                 acc[name] = ProjectNativeTarget(

--- a/Tests/XcodeGraphMapperTests/TestData/PBXNativeTarget+TestData.swift
+++ b/Tests/XcodeGraphMapperTests/TestData/PBXNativeTarget+TestData.swift
@@ -12,6 +12,7 @@ extension PBXNativeTarget {
         ],
         dependencies: [PBXTargetDependency] = [],
         productInstallPath: String? = nil,
+        productName: String? = nil,
         productType: PBXProductType = .application,
         product: PBXFileReference? = PBXFileReference.test(
             sourceTree: .buildProductsDir,
@@ -28,7 +29,7 @@ extension PBXNativeTarget {
             buildRules: buildRules,
             dependencies: dependencies,
             productInstallPath: productInstallPath,
-            productName: name,
+            productName: productName ?? name,
             product: product,
             productType: productType
         )


### PR DESCRIPTION
Resolves issue raised [here](https://community.tuist.dev/t/selective-testing-for-non-generated-projects/381/14).

In Pods projects, the resource bundle added as a dependency uses the product name. However, the target name can be different such`Alamofire-iOS-Alamofire` bundle's product name is `Alamofire`. When creating the `projectNativeTargets` map, we use the product name as the key, so we don't [throw here](https://github.com/tuist/XcodeGraph/blob/main/Sources/XcodeGraphMapper/Mappers/Phases/PBXResourcesBuildPhaseMapper.swift#L107).

Note this can cause a mismatch when the targets have a different name but the same product name. I couldn't figure out a good way to match the bundle product name with a specific target when there are multiple targets with the same product. I'd think this is quite rare outside of the Cocoapods context, so I'm leaning to living with that for now and reconsider this if it causes issues down the line.