### PR TITLE
feat: add support for defining Info.plist files using a variable

### DIFF
--- a/Sources/XcodeGraph/Models/Plist.swift
+++ b/Sources/XcodeGraph/Models/Plist.swift
@@ -126,7 +126,7 @@ public enum InfoPlist: Equatable, Codable, Sendable {
 
 extension InfoPlist: ExpressibleByStringLiteral {
     public init(stringLiteral value: String) {
-        let regexPattern = #"^\$\((.+)\)$|^\$\{(.+)\}$"#
+        let regexPattern = #"^\$\((.+)\)|^\$\{(.+)\}"#
         if let _ = value.range(of: regexPattern, options: .regularExpression) {
             self = .variable(value)
         } else {

--- a/Sources/XcodeGraph/Models/Plist.swift
+++ b/Sources/XcodeGraph/Models/Plist.swift
@@ -103,6 +103,9 @@ public enum InfoPlist: Equatable, Codable, Sendable {
     // User defined dictionary of keys/values for an info.plist file.
     case dictionary([String: Plist.Value], configuration: BuildConfiguration? = nil)
 
+    // A user defined xcconfig variable map to .entitlements file
+    case variable(String, configuration: BuildConfiguration? = nil)
+
     // User defined dictionary of keys/values for an info.plist file extending the default set of keys/values
     // for the target type.
     case extendingDefault(with: [String: Plist.Value], configuration: BuildConfiguration? = nil)
@@ -123,7 +126,12 @@ public enum InfoPlist: Equatable, Codable, Sendable {
 
 extension InfoPlist: ExpressibleByStringLiteral {
     public init(stringLiteral value: String) {
-        self = .file(path: try! AbsolutePath(validating: value)) // swiftlint:disable:this force_try
+        let regexPattern = #"^\$\((.+)\)$|^\$\{(.+)\}$"#
+        if let _ = value.range(of: regexPattern, options: .regularExpression) {
+            self = .variable(value)
+        } else {
+            self = .file(path: try! AbsolutePath(validating: value)) // swiftlint:disable:this force_try
+        }
     }
 }
 

--- a/Tests/XcodeGraphTests/Models/InfoPlistTests.swift
+++ b/Tests/XcodeGraphTests/Models/InfoPlistTests.swift
@@ -41,4 +41,14 @@ final class InfoPlistTests: XCTestCase {
         // Then
         XCTAssertEqual(subject.path, try AbsolutePath(validating: "/path/Info.list"))
     }
+
+    func test_expressive_by_string_literal_using_build_variable() {
+        // Given
+        let subject1: InfoPlist = "$(CONFIGURATION)/Info.list"
+        let subject2: InfoPlist = "${CONFIGURATION}/Info.list"
+
+        // Then
+        XCTAssertEqual(subject1, .variable("$(CONFIGURATION)/Info.list", configuration: nil))
+        XCTAssertEqual(subject2, .variable("${CONFIGURATION}/Info.list", configuration: nil))
+    }
 }


### PR DESCRIPTION
This PR implements the support for variable InfoPlist file paths for build settings that mirrors the existing API for setting variable entitlements file paths. The issue has been described in detail here: https://github.com/tuist/tuist/issues/6727

This change is needed to unblock https://github.com/tuist/tuist/pull/7404