### PR TITLE
feat: make `XcodeMetadata` a product of the package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -74,6 +74,7 @@ let package = Package(
             name: "XcodeGraph",
             targets: ["XcodeGraph"]
         ),
+        .library(name: "XcodeMetadata", targets: ["XcodeMetadata"]),
         .library(name: "XcodeGraphMapper", targets: ["XcodeGraphMapper"]),
     ],
     dependencies: [


### PR DESCRIPTION
The detection of implicit imports [fails in this PR](https://codemagic.io/app/65ca555c190cfbe9f5dd792f/build/682db45ca34be27ad16d5499#step:6) because `XcodeMetadata` is not explicitly declared as a dependency, but I can't declare it because it's actually not defined as a product here.
I'm adjusting the `Package.swift` to make the target also a valid product that can be used downstream.