### PR TITLE
feat: add support for CoreData source files

### DIFF
--- a/Sources/XcodeGraph/Models/Target.swift
+++ b/Sources/XcodeGraph/Models/Target.swift
@@ -8,7 +8,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
     // Note: The `.docc` file type is technically both a valid source extension and folder extension
     //       in order to compile the documentation archive (including Tutorials, Articles, etc.)
     public static let validSourceCompatibleFolderExtensions: [String] = [
-        "playground", "rcproject", "mlpackage", "docc",
+        "playground", "rcproject", "mlpackage", "docc", "xcdatamodeld", "xcmappingmodel"
     ]
     public static let validSourceExtensions: [String] = [
         "m", "swift", "mm", "cpp", "c++", "cc", "c", "d", "s", "intentdefinition", "metal", "mlmodel", "clp",

--- a/Sources/XcodeGraph/Models/Target.swift
+++ b/Sources/XcodeGraph/Models/Target.swift
@@ -8,7 +8,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
     // Note: The `.docc` file type is technically both a valid source extension and folder extension
     //       in order to compile the documentation archive (including Tutorials, Articles, etc.)
     public static let validSourceCompatibleFolderExtensions: [String] = [
-        "playground", "rcproject", "mlpackage", "docc", "xcdatamodeld", "xcmappingmodel",
+        "playground", "rcproject", "mlpackage", "docc", "xcmappingmodel",
     ]
     public static let validSourceExtensions: [String] = [
         "m", "swift", "mm", "cpp", "c++", "cc", "c", "d", "s", "intentdefinition", "metal", "mlmodel", "clp",

--- a/Sources/XcodeGraph/Models/Target.swift
+++ b/Sources/XcodeGraph/Models/Target.swift
@@ -8,7 +8,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
     // Note: The `.docc` file type is technically both a valid source extension and folder extension
     //       in order to compile the documentation archive (including Tutorials, Articles, etc.)
     public static let validSourceCompatibleFolderExtensions: [String] = [
-        "playground", "rcproject", "mlpackage", "docc", "xcdatamodeld", "xcmappingmodel"
+        "playground", "rcproject", "mlpackage", "docc", "xcdatamodeld", "xcmappingmodel",
     ]
     public static let validSourceExtensions: [String] = [
         "m", "swift", "mm", "cpp", "c++", "cc", "c", "d", "s", "intentdefinition", "metal", "mlmodel", "clp",


### PR DESCRIPTION
I am migrating a big project to use Tuist and I'm looking at how to integrate xcdatamodeld and xcdatamodelmapping files. In the project I am migrating from, those files are all added in the Compile Source build phase and nothing in resources.
In Tuist:
- I can't use Target.sources as they are not among the "whitelisted" sources
Is there a reason why it's not allowed
- If I use Target.coreDataModels I can only add xcdatamodeld and inner xcdatamodel which are added to BOTH sources and resources

This is why I'm updating the valid source extensions to include `xcdatamodeld` as well.