### PR TITLE
feat: Extend the BuildAction to allow setting the architecture

### DIFF
--- a/Sources/XcodeGraph/Models/BuildAction+Architectures.swift
+++ b/Sources/XcodeGraph/Models/BuildAction+Architectures.swift
@@ -1,0 +1,7 @@
+extension BuildAction {
+    public enum Architectures: Equatable, Codable, Sendable {
+        case matchRunDestination
+        case universal
+        case useTargetSettings
+    }
+}

--- a/Sources/XcodeGraph/Models/BuildAction.swift
+++ b/Sources/XcodeGraph/Models/BuildAction.swift
@@ -10,6 +10,7 @@ public struct BuildAction: Equatable, Codable, Sendable {
     public var parallelizeBuild: Bool
     public var runPostActionsOnFailure: Bool
     public var findImplicitDependencies: Bool
+    public var overrideArchitectures: Architectures
 
     // MARK: - Init
 
@@ -19,7 +20,8 @@ public struct BuildAction: Equatable, Codable, Sendable {
         postActions: [ExecutionAction] = [],
         parallelizeBuild: Bool = true,
         runPostActionsOnFailure: Bool = false,
-        findImplicitDependencies: Bool = true
+        findImplicitDependencies: Bool = true,
+        overrideArchitectures: Architectures = .useTargetSettings
     ) {
         self.targets = targets
         self.preActions = preActions
@@ -27,6 +29,7 @@ public struct BuildAction: Equatable, Codable, Sendable {
         self.parallelizeBuild = parallelizeBuild
         self.runPostActionsOnFailure = runPostActionsOnFailure
         self.findImplicitDependencies = findImplicitDependencies
+        self.overrideArchitectures = overrideArchitectures
     }
 }
 

--- a/Tests/XcodeGraphTests/Models/BuildAction.ArchitecturesTests.swift
+++ b/Tests/XcodeGraphTests/Models/BuildAction.ArchitecturesTests.swift
@@ -1,0 +1,14 @@
+import Foundation
+import XCTest
+
+@testable import XcodeGraph
+
+final class BuildActionArchitecturesTests: XCTestCase {
+    func test_codable() {
+        // Given
+        let subject = BuildAction.Architectures.universal
+
+        // Then
+        XCTAssertCodable(subject)
+    }
+}


### PR DESCRIPTION
Add a parameter in the BuildAction to be able to set the architecture strategy for the scheme. 