### PR TITLE
feat: Add Target.buildableFolders attribute

### DIFF
--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -1,18 +1,15 @@
 name: conventional-pr
 on:
-  pull_request:
-    branches:
-      - main
-      - master
-    types:
-      - opened
-      - edited
-      - synchronize
+  pull_request: {}
+
 jobs:
   lint-pr:
+    name: Lint PR
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: CondeNast/conventional-pull-request-action@v0.2.0
+      - uses: amannn/action-semantic-pull-request@v5
+        with:
+          requireScope: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@v5
       - uses: amannn/action-semantic-pull-request@v5
         with:
-          requireScope: true
+          requireScope: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8f7ec11605d33c49dbca76c7a21b5bd815e6cf5bb841293a364d2ecc96d68509",
+  "originHash" : "505645cbb783e49767bfc742c0bb9feef1221fa8bd51dda3c6497ea1c2598b4c",
   "pins" : [
     {
       "identity" : "aexml",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/FileSystem.git",
       "state" : {
-        "revision" : "1fa815a9fae52c8df462f80a7d19f2d72afb2a0c",
-        "version" : "0.10.15"
+        "revision" : "23bcf23ce85edb653817a34c42c5140b16a6132c",
+        "version" : "0.11.5"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/p-x9/MachOKit",
       "state" : {
-        "revision" : "d0b543aa795d83539691b80959b0adb152b072e7",
-        "version" : "0.35.1"
+        "revision" : "5a09d8ad1be010bcd58d8a39554480b19e0a45e1",
+        "version" : "0.37.0"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/p-x9/swift-fileio.git",
       "state" : {
-        "revision" : "23349fe1eb23c6ca2876d461a46ff60c0fa92f9c",
-        "version" : "0.9.0"
+        "revision" : "63daf8e8402789339ccc5a19d198ff0fcafd29d9",
+        "version" : "0.11.0"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",
       "state" : {
-        "revision" : "3d8596ed08bd13520157f0355e35caed215ffbfa",
-        "version" : "1.6.3"
+        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
+        "version" : "1.6.4"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio",
       "state" : {
-        "revision" : "ad6b5f17270a7008f60d35ec5378e6144a575162",
-        "version" : "2.84.0"
+        "revision" : "1c30f0f2053b654e3d1302492124aa6d242cdba7",
+        "version" : "2.86.0"
       }
     },
     {

--- a/Sources/XcodeGraph/Models/BuildableFolder.swift
+++ b/Sources/XcodeGraph/Models/BuildableFolder.swift
@@ -4,7 +4,7 @@ import Path
 /// Synchronized groups were introduced in Xcode 16 to reduce git conflicts by having a reference
 /// to a folder whose content is "synchronized" by Xcode itself. Think of it as Xcode resolving
 /// the globs.
-public struct BuildableFolder: Sendable, Codable {
+public struct BuildableFolder: Sendable, Codable, Equatable, Hashable {
     /// The absolute path to the buildable folder.
     public var path: AbsolutePath
 

--- a/Sources/XcodeGraph/Models/BuildableFolder.swift
+++ b/Sources/XcodeGraph/Models/BuildableFolder.swift
@@ -1,0 +1,16 @@
+import Path
+
+/// A buildable folder maps to an PBXFileSystemSynchronizedRootGroup in Xcode projects.
+/// Synchronized groups were introduced in Xcode 16 to reduce git conflicts by having a reference
+/// to a folder whose content is "synchronized" by Xcode itself. Think of it as Xcode resolving
+/// the globs.
+public struct BuildableFolder: Sendable, Codable {
+    /// The absolute path to the buildable folder.
+    public var path: AbsolutePath
+
+    /// Creates an instance of buildable folder.
+    /// - Parameter path: Absolute path to the buildable folder.
+    public init(path: AbsolutePath) {
+        self.path = path
+    }
+}

--- a/Sources/XcodeGraph/Models/Target.swift
+++ b/Sources/XcodeGraph/Models/Target.swift
@@ -444,7 +444,7 @@ extension Sequence<Target> {
             mergedBinaryType: MergedBinaryType = .disabled,
             mergeable: Bool = false,
             metadata: TargetMetadata = .test(),
-            buildableFolders: [BuildableFolder] = [],
+            buildableFolders: [BuildableFolder] = []
         ) -> Target {
             Target(
                 name: name,

--- a/Sources/XcodeGraph/Models/Target.swift
+++ b/Sources/XcodeGraph/Models/Target.swift
@@ -62,8 +62,8 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
     public let onDemandResourcesTags: OnDemandResourcesTags?
     public let metadata: TargetMetadata
     public let type: TargetType
-    /// Package directories
     public let packages: [AbsolutePath]
+    public let buildableFolders: [BuildableFolder]
 
     // MARK: - Init
 
@@ -97,7 +97,8 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
         onDemandResourcesTags: OnDemandResourcesTags? = nil,
         metadata: TargetMetadata = .metadata(tags: []),
         type: TargetType = .local,
-        packages: [AbsolutePath] = []
+        packages: [AbsolutePath] = [],
+        buildableFolders: [BuildableFolder] = []
     ) {
         self.name = name
         self.product = product
@@ -129,6 +130,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
         self.metadata = metadata
         self.type = type
         self.packages = packages
+        self.buildableFolders = buildableFolders
     }
 
     /// Given a target name, it obtains the product name by turning "-" characters into "_" and "/" into "_"
@@ -441,7 +443,8 @@ extension Sequence<Target> {
             prune: Bool = false,
             mergedBinaryType: MergedBinaryType = .disabled,
             mergeable: Bool = false,
-            metadata: TargetMetadata = .test()
+            metadata: TargetMetadata = .test(),
+            buildableFolders: [BuildableFolder] = [],
         ) -> Target {
             Target(
                 name: name,
@@ -469,7 +472,8 @@ extension Sequence<Target> {
                 prune: prune,
                 mergedBinaryType: mergedBinaryType,
                 mergeable: mergeable,
-                metadata: metadata
+                metadata: metadata,
+                buildableFolders: buildableFolders
             )
         }
 
@@ -501,7 +505,8 @@ extension Sequence<Target> {
             prune: Bool = false,
             mergedBinaryType: MergedBinaryType = .disabled,
             mergeable: Bool = false,
-            metadata: TargetMetadata = .test()
+            metadata: TargetMetadata = .test(),
+            buildableFolders: [BuildableFolder] = []
         ) -> Target {
             Target(
                 name: name,
@@ -529,7 +534,8 @@ extension Sequence<Target> {
                 prune: prune,
                 mergedBinaryType: mergedBinaryType,
                 mergeable: mergeable,
-                metadata: metadata
+                metadata: metadata,
+                buildableFolders: buildableFolders
             )
         }
 
@@ -554,7 +560,8 @@ extension Sequence<Target> {
             filesGroup: ProjectGroup = .group(name: "Project"),
             dependencies: [TargetDependency] = [],
             rawScriptBuildPhases: [RawScriptBuildPhase] = [],
-            onDemandResourcesTags: OnDemandResourcesTags? = nil
+            onDemandResourcesTags: OnDemandResourcesTags? = nil,
+            buildableFolders: [BuildableFolder] = []
         ) -> Target {
             Target(
                 name: name,
@@ -576,7 +583,8 @@ extension Sequence<Target> {
                 filesGroup: filesGroup,
                 dependencies: dependencies,
                 rawScriptBuildPhases: rawScriptBuildPhases,
-                onDemandResourcesTags: onDemandResourcesTags
+                onDemandResourcesTags: onDemandResourcesTags,
+                buildableFolders: buildableFolders
             )
         }
 


### PR DESCRIPTION
I'm adding `Target.buildableFolders` attribute that we can use to support buildable folders in Tuist. Note that I leaned on naming the attribute `buildableFolders` because this is the name that it's being used publicly (`.pbxproj` uses synchronized root group). The breadth of options in pbxproj is much larger, which means we can't support mapping from pbxproj to `XcodeGraph` until we include those too, so I leaned on doing that in a follow-up PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for representing buildable folders in Xcode projects.
  * Added the ability to associate buildable folders with targets.

* **Chores**
  * Updated dependency versions.
  * Improved pull request validation workflow for consistency and broader coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->