### PR TITLE
feat: Make Target.metadata mutable and mark prune as deprecated

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "505645cbb783e49767bfc742c0bb9feef1221fa8bd51dda3c6497ea1c2598b4c",
+  "originHash" : "3723bf697fd3c9deb411523eef2023627c93557d8d2729d3e438c927a4be3b5c",
   "pins" : [
     {
       "identity" : "aexml",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/FileSystem.git",
       "state" : {
-        "revision" : "23bcf23ce85edb653817a34c42c5140b16a6132c",
-        "version" : "0.11.5"
+        "revision" : "d2f49d5a9f8ada3b6e1a2bc4254d715b214d5753",
+        "version" : "0.11.8"
       }
     },
     {
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj",
       "state" : {
-        "revision" : "9799bb429fda8e360f4c535af1716bebc89fb235",
-        "version" : "9.4.3"
+        "revision" : "e1f2a4365669e02272b2f381b13a2378b15fb485",
+        "version" : "9.5.0"
       }
     },
     {

--- a/Sources/XcodeGraph/Models/Target.swift
+++ b/Sources/XcodeGraph/Models/Target.swift
@@ -56,11 +56,16 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
     public var playgrounds: [AbsolutePath]
     public let additionalFiles: [FileElement]
     public var buildRules: [BuildRule]
+    @available(*, deprecated, message: """
+    The prune attribute coupled XcodeGraph to a particular use-case of Tuist and therefore
+    we removed it in favor of using metadata as an in-memory context holder that can be leveraged
+    using conventional tags.
+    """)
     public var prune: Bool
     public let mergedBinaryType: MergedBinaryType
     public let mergeable: Bool
     public let onDemandResourcesTags: OnDemandResourcesTags?
-    public let metadata: TargetMetadata
+    public var metadata: TargetMetadata
     public let type: TargetType
     public let packages: [AbsolutePath]
     public let buildableFolders: [BuildableFolder]


### PR DESCRIPTION
While working on a Tuist feature that allows keeping the sources of the targets that have been replaced by binaries, I realized the `Target.prune` attribute was tied to a Tuist's specific use case.

I believe XcodeGraph should be generic, like middlewares like `Plug` are to web servers, and that we should design `XcodeGraph` models to be as generic as possible. Therefore, I'm marking it as deprecated. Instead, I'm going to use `Target.metadata`, which can play the role of holding context in memory, in the same way conn assigns do in Elixir. For example, we can use the tag `tuist:prunable`, to mark a target to be _prunable_ in a way that doesn't couple the design of `XcodeGraph.Target` to a specific use case.