### PR TITLE
feat: make `loadXCTestMetadata` method public

### DIFF
--- a/Sources/XcodeMetadata/Providers/SystemFrameworkMetadataProvider.swift
+++ b/Sources/XcodeMetadata/Providers/SystemFrameworkMetadataProvider.swift
@@ -28,7 +28,7 @@ public protocol SystemFrameworkMetadataProviding {
 }
 
 extension SystemFrameworkMetadataProviding {
-    func loadXCTestMetadata(platform: Platform) throws -> SystemFrameworkMetadata {
+    public func loadXCTestMetadata(platform: Platform) throws -> SystemFrameworkMetadata {
         try loadMetadata(sdkName: "XCTest.framework", status: .required, platform: platform, source: .developer)
     }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/XcodeGraph/issues/262 [^1]

Changed the access level of `loadXCTestMetadata` to public in the `SystemFrameworkMetadataProviding` extension to allow usage in [`cli/Sources/TuistCore/Graph/GraphLoader.swift`](https://github.com/tuist/tuist/blob/dd79908b5ee741bd80ef29020f527528ab27f76c/cli/Sources/TuistCore/Graph/GraphLoader.swift#L308)

[^1]: https://github.com/tuist/tuist/issues/7973#issuecomment-3195917874