### PR TITLE
feat: include `publicHeaders` and `privateHeaders` in buildable folder exceptions

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "88fcdf8451554503ef74eb5a6e07f1c3b4af720431bfc6f6ba1d606475e66ced",
+  "originHash" : "f98459e09386972f6e7eac37cf84e7db5eff69ccfdb6f67c5d5bfda323ca5778",
   "pins" : [
     {
       "identity" : "aexml",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/FileSystem.git",
       "state" : {
-        "revision" : "1e8890203abfc0dcd887b49ec5e91ea75b394495",
-        "version" : "0.11.23"
+        "revision" : "42df856138ba27cc1ed59358a37b86e7ea31051e",
+        "version" : "0.12.3"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio",
       "state" : {
-        "revision" : "1c30f0f2053b654e3d1302492124aa6d242cdba7",
-        "version" : "2.86.0"
+        "revision" : "a18bddb0acf7a40d982b2f128ce73ce4ee31f352",
+        "version" : "2.86.2"
       }
     },
     {

--- a/Sources/XcodeGraph/Models/BuildableFolderException.swift
+++ b/Sources/XcodeGraph/Models/BuildableFolderException.swift
@@ -8,12 +8,27 @@ public struct BuildableFolderException: Sendable, Codable, Equatable, Hashable {
     /// A dictionary mapping files (referenced by their absolute path) to the compiler flags to apply.
     public var compilerFlags: [AbsolutePath: String]
 
+    /// The list of public headers.
+    public var publicHeaders: [AbsolutePath]
+
+    /// The list of private headers.
+    public var privateHeaders: [AbsolutePath]
+
     /// Creates a new exception for a buildable folder.
     /// - Parameters:
     ///   - excluded: An array of absolute paths to files that should be excluded from the buildable folder.
     ///   - compilerFlags: A dictionary mapping absolute file paths to specific compiler flags to apply to those files.
-    public init(excluded: [AbsolutePath], compilerFlags: [AbsolutePath: String]) {
+    ///   - publicHeaders: The list of public headers.
+    ///   - privateHeaders: The list of private headers.
+    public init(
+        excluded: [AbsolutePath],
+        compilerFlags: [AbsolutePath: String],
+        publicHeaders: [AbsolutePath],
+        privateHeaders: [AbsolutePath]
+    ) {
         self.excluded = excluded
         self.compilerFlags = compilerFlags
+        self.publicHeaders = publicHeaders
+        self.privateHeaders = privateHeaders
     }
 }


### PR DESCRIPTION
By default they have the project access level so we need this to allow users to control the access level.