### PR TITLE
feat: add support for defaultIsolation setting in PackageInfo

### DIFF
--- a/Sources/XcodeGraph/PackageInfo.swift
+++ b/Sources/XcodeGraph/PackageInfo.swift
@@ -449,6 +449,7 @@ extension PackageInfo.Target {
             case enableUpcomingFeature
             case enableExperimentalFeature
             case interoperabilityMode
+            case defaultIsolation
         }
 
         /// An individual build setting.
@@ -499,6 +500,7 @@ extension PackageInfo.Target {
                 case enableUpcomingFeature(String)
                 case enableExperimentalFeature(String)
                 case interoperabilityMode(String)
+                case defaultIsolation(String)
             }
 
             public init(from decoder: Decoder) throws {
@@ -535,6 +537,9 @@ extension PackageInfo.Target {
                     case let .swiftLanguageMode(value):
                         name = .swiftLanguageMode
                         self.value = [value]
+                    case let .defaultIsolation(value):
+                        name = .defaultIsolation
+                        self.value = [value]
                     }
                 } else {
                     name = try container.decode(SettingName.self, forKey: .name)
@@ -566,6 +571,8 @@ extension PackageInfo.Target {
                     try container.encode(Kind.enableExperimentalFeature(value.first!), forKey: .kind)
                 case .swiftLanguageMode:
                     try container.encode(Kind.swiftLanguageMode(value.first!), forKey: .kind)
+                case .defaultIsolation:
+                    try container.encode(Kind.defaultIsolation(value.first!), forKey: .kind)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Adds support for the `defaultIsolation` Swift Package Manager setting introduced in PackageDescription 6.2
- Resolves https://github.com/tuist/tuist/issues/8367

## Changes
- Added `defaultIsolation` case to `SettingName` enum
- Added `defaultIsolation` case to private `Kind` enum for Xcode 14 format
- Updated `init(from:)` decoder to handle `defaultIsolation` settings
- Updated `encode(to:)` encoder to handle `defaultIsolation` settings

## Context
The `defaultIsolation` setting allows Swift packages to specify actor isolation requirements for their targets (e.g., `.defaultIsolation(nil)` for nonisolated or `.defaultIsolation(MainActor.self)` for MainActor isolated).

Without this support, Tuist fails to parse PackageInfo JSON when packages use this setting, causing project generation to fail with a decoding error.

## Test Plan
- Verified that PackageInfo can now decode `defaultIsolation` settings without errors
- The setting is properly ignored during project generation (handled in tuist/tuist repository)

🤖 Generated with [Claude Code](https://claude.com/claude-code)