### PR TITLE
fix: Add 'txt', 'js' and 'json' to valid resource extensions

### DIFF
--- a/Sources/XcodeGraph/Models/Target.swift
+++ b/Sources/XcodeGraph/Models/Target.swift
@@ -16,7 +16,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
     public static let validResourceExtensions: [String] = [
         // Resource
         "md", "xcstrings", "plist", "rtf", "tutorial", "sks", "xcprivacy", "gpx", "strings", "stringsdict",
-        "geojson", "txt", "json",
+        "geojson", "txt", "json", "js",
 
         // User interface
         "storyboard", "xib",


### PR DESCRIPTION
The resources of type `txt`, `js` and `json` weren't considered valid resource extensions.

The lack of them in the array caused this bug in Tuist: https://github.com/tuist/tuist/issues/8126

This PR adds these two extensions.