### PR TITLE
feat: Add support for disableWarning CSetting

### DIFF
--- a/Sources/XcodeGraph/PackageInfo.swift
+++ b/Sources/XcodeGraph/PackageInfo.swift
@@ -456,6 +456,7 @@ extension PackageInfo.Target {
             case interoperabilityMode
             case defaultIsolation
             case strictMemorySafety
+            case disableWarning
         }
 
         /// An individual build setting.
@@ -508,6 +509,7 @@ extension PackageInfo.Target {
                 case interoperabilityMode(String)
                 case defaultIsolation(String)
                 case strictMemorySafety(String)
+                case disableWarning(String)
             }
 
             enum SettingDecodingError: LocalizedError {
@@ -569,6 +571,9 @@ extension PackageInfo.Target {
                     case let .strictMemorySafety(value):
                         name = .strictMemorySafety
                         self.value = [value]
+                    case let .disableWarning(value):
+                        name = .disableWarning
+                        self.value = [value]
                     }
                 } else {
                     // Legacy format - try to decode name
@@ -615,6 +620,8 @@ extension PackageInfo.Target {
                     try container.encode(Kind.defaultIsolation(value.first!), forKey: .kind)
                 case .strictMemorySafety:
                     try container.encode(Kind.strictMemorySafety(value.first!), forKey: .kind)
+                case .disableWarning:
+                    try container.encode(Kind.disableWarning(value.first!), forKey: .kind)
                 }
             }
         }


### PR DESCRIPTION
## Summary

Add support for SwiftPM's `disableWarning` CSetting in PackageInfo. This allows packages to disable specific compiler warnings using the [`disableWarning(_:_:)`](https://docs.swift.org/swiftpm/documentation/packagedescription/csetting/disablewarning(_:_:)/) API.

## Changes

- Add `disableWarning` case to `SettingName` enum
- Add `disableWarning(String)` case to `Kind` enum for Xcode 14+ format
- Add encoding/decoding support for the `disableWarning` setting

## Example Usage

```swift
.target(
    name: "MyTarget",
    cSettings: [
        .disableWarning("unused-variable")
    ]
)
```

This will be mapped to the appropriate compiler flags (e.g., `-Wno-unused-variable`) when converted to Xcode build settings.

## Related

This is part of adding full support for `disableWarning` in Tuist's SwiftPM integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)